### PR TITLE
Fix URL for hub.load() for new MiDaS models

### DIFF
--- a/assets/docs/intel/midas/v2/1/2.md
+++ b/assets/docs/intel/midas/v2/1/2.md
@@ -22,7 +22,7 @@ Rene Ranftl, Katrin Lasinger, David Hafner, Konrad Schindler, Vladlen Koltun in 
 #### Requirements
 
 ```
-pip install tensorflow tensorflow-hub opencv-python
+pip install tensorflow tensorflow-hub opencv-python matplotlib
 ```
 
 * required nVidia GPU
@@ -39,6 +39,7 @@ This module is based on a Pytorch version of MiDaS, which performs efficiently a
 import cv2
 import numpy as np
 import urllib.request
+import matplotlib.pyplot as plt
 
 import tensorflow as tf
 import tensorflow_hub as hub
@@ -64,7 +65,7 @@ reshape_img = img_input.reshape(1,3,384,384)
 tensor = tf.convert_to_tensor(reshape_img, dtype=tf.float32)
 
 # load model
-module = hub.load("https://tfhub.dev/intel/midas/v2_1/1", tags=['serve'])
+module = hub.load("https://tfhub.dev/intel/midas/v2/2", tags=['serve'])
 output = module.signatures['serving_default'](tensor)
 prediction = output['default'].numpy()
 prediction = prediction.reshape(384, 384)
@@ -75,7 +76,10 @@ print(" Write image to: output.png")
 depth_min = prediction.min()
 depth_max = prediction.max()
 img_out = (255 * (prediction - depth_min) / (depth_max - depth_min)).astype("uint8")
+
 cv2.imwrite("output.png", img_out)
+plt.imshow(img_out)
+# plt.show()
 
 ```
 

--- a/assets/docs/intel/midas/v2/1/2.md
+++ b/assets/docs/intel/midas/v2/1/2.md
@@ -1,0 +1,83 @@
+# Module intel/midas/v2/2
+Convolutional neural network for monocular depth estimation from a single RGB image.
+
+<!-- asset-path: https://github.com/intel-isl/MiDaS/releases/download/v2_1/model_hub.tar.gz -->
+<!-- module-type: image-depth-estimation -->
+<!-- network-architecture: MiDaS -->
+<!-- dataset: DIML Indoor, MegaDepth, ReDWeb, WSVD, 3D Movies, TartanAir, HRWSI, ApolloScape, BlendedMVS, IRS -->
+<!-- fine-tunable: false  -->
+<!-- format: hub -->
+<!-- license: MIT -->
+
+## License
+MIT License
+
+## Qualitative Information
+
+This MiDaS model is converted from the original version of the [MiDaS model](https://github.com/intel-isl/MiDaS). 
+MiDaS was first introduced by
+Rene Ranftl, Katrin Lasinger, David Hafner, Konrad Schindler, Vladlen Koltun in the paper:
+[Towards Robust Monocular Depth Estimation: Mixing Datasets for Zero-shot Cross-dataset Transfer](https://arxiv.org/abs/1907.01341).
+
+#### Requirements
+
+```
+pip install tensorflow tensorflow-hub opencv-python
+```
+
+* required nVidia GPU
+
+#### Model Details
+This module is based on a Pytorch version of MiDaS, which performs efficiently and with very high accuracy to compute depth from a single image.
+
+* input: (uint8) RGB image with shape (3, 384, 384)
+* output: (float32) inverse depth maps (1, 384, 384)
+
+#### Example Use
+
+```python
+import cv2
+import numpy as np
+import urllib.request
+
+import tensorflow as tf
+import tensorflow_hub as hub
+
+url, filename = ("https://github.com/intel-isl/MiDaS/releases/download/v2/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+
+# the runtime initialization will not allocate all memory on the device to avoid out of GPU memory
+gpus = tf.config.experimental.list_physical_devices('GPU')
+for gpu in gpus:
+    #tf.config.experimental.set_memory_growth(gpu, True)
+    tf.config.experimental.set_virtual_device_configuration(gpu,
+    [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=4000)])
+
+# input
+img = cv2.imread('dog.jpg')
+img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) / 255.0
+
+img_resized = tf.image.resize(img, [384,384], method='bicubic', preserve_aspect_ratio=False)
+img_resized = tf.transpose(img_resized, [2, 0, 1])
+img_input = img_resized.numpy()
+reshape_img = img_input.reshape(1,3,384,384)
+tensor = tf.convert_to_tensor(reshape_img, dtype=tf.float32)
+
+# load model
+module = hub.load("https://tfhub.dev/intel/midas/v2_1/1", tags=['serve'])
+output = module.signatures['serving_default'](tensor)
+prediction = output['default'].numpy()
+prediction = prediction.reshape(384, 384)
+             
+# output file
+prediction = cv2.resize(prediction, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_CUBIC)
+print(" Write image to: output.png")
+depth_min = prediction.min()
+depth_max = prediction.max()
+img_out = (255 * (prediction - depth_min) / (depth_max - depth_min)).astype("uint8")
+cv2.imwrite("output.png", img_out)
+
+```
+
+
+**Source:** https://github.com/intel-isl/MiDaS

--- a/assets/docs/intel/midas/v2_1_small/1/1.md
+++ b/assets/docs/intel/midas/v2_1_small/1/1.md
@@ -1,0 +1,83 @@
+# Module intel/midas/v2_1_small/1
+Mobile convolutional neural network for monocular depth estimation from a single RGB image.
+
+<!-- asset-path: https://github.com/intel-isl/MiDaS/releases/download/v2_1/model_hub_small.tar.gz -->
+<!-- module-type: image-depth-estimation -->
+<!-- network-architecture: MiDaS -->
+<!-- dataset: DIML Indoor, MegaDepth, ReDWeb, WSVD, 3D Movies, TartanAir, HRWSI, ApolloScape, BlendedMVS, IRS -->
+<!-- fine-tunable: false  -->
+<!-- format: hub -->
+<!-- license: MIT -->
+
+## License
+MIT License
+
+## Qualitative Information
+
+This MiDaS model is converted from the original version of the [MiDaS model](https://github.com/intel-isl/MiDaS). 
+MiDaS was first introduced by
+Rene Ranftl, Katrin Lasinger, David Hafner, Konrad Schindler, Vladlen Koltun in the paper:
+[Towards Robust Monocular Depth Estimation: Mixing Datasets for Zero-shot Cross-dataset Transfer](https://arxiv.org/abs/1907.01341).
+
+#### Requirements
+
+```
+pip install tensorflow tensorflow-hub opencv-python
+```
+
+* required nVidia GPU
+
+#### Model Details
+This module is based on a Pytorch version of MiDaS, which performs efficiently and with very high accuracy to compute depth from a single image.
+
+* input: (uint8) RGB image with shape (3, 256, 256)
+* output: (float32) inverse depth maps (1, 256, 256)
+
+#### Example Use
+
+```python
+import cv2
+import numpy as np
+import urllib.request
+
+import tensorflow as tf
+import tensorflow_hub as hub
+
+url, filename = ("https://github.com/intel-isl/MiDaS/releases/download/v2/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+
+# the runtime initialization will not allocate all memory on the device to avoid out of GPU memory
+gpus = tf.config.experimental.list_physical_devices('GPU')
+for gpu in gpus:
+    #tf.config.experimental.set_memory_growth(gpu, True)
+    tf.config.experimental.set_virtual_device_configuration(gpu,
+    [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=4000)])
+
+# input
+img = cv2.imread('dog.jpg')
+img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) / 255.0
+
+img_resized = tf.image.resize(img, [256,256], method='bicubic', preserve_aspect_ratio=False)
+img_resized = tf.transpose(img_resized, [2, 0, 1])
+img_input = img_resized.numpy()
+reshape_img = img_input.reshape(1,3,256,256)
+tensor = tf.convert_to_tensor(reshape_img, dtype=tf.float32)
+
+# load model
+module = hub.load("https://tfhub.dev/intel/midas/v2_1/2", tags=['serve'])
+output = module.signatures['serving_default'](tensor)
+prediction = output['default'].numpy()
+prediction = prediction.reshape(256, 256)
+             
+# output file
+prediction = cv2.resize(prediction, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_CUBIC)
+print(" Write image to: output.png")
+depth_min = prediction.min()
+depth_max = prediction.max()
+img_out = (255 * (prediction - depth_min) / (depth_max - depth_min)).astype("uint8")
+cv2.imwrite("output.png", img_out)
+
+```
+
+
+**Source:** https://github.com/intel-isl/MiDaS

--- a/assets/docs/intel/midas/v2_1_small/1/1.md
+++ b/assets/docs/intel/midas/v2_1_small/1/1.md
@@ -22,7 +22,7 @@ Rene Ranftl, Katrin Lasinger, David Hafner, Konrad Schindler, Vladlen Koltun in 
 #### Requirements
 
 ```
-pip install tensorflow tensorflow-hub opencv-python
+pip install tensorflow tensorflow-hub opencv-python matplotlib
 ```
 
 * required nVidia GPU
@@ -39,6 +39,7 @@ This module is based on a Pytorch version of MiDaS, which performs efficiently a
 import cv2
 import numpy as np
 import urllib.request
+import matplotlib.pyplot as plt
 
 import tensorflow as tf
 import tensorflow_hub as hub
@@ -64,7 +65,7 @@ reshape_img = img_input.reshape(1,3,256,256)
 tensor = tf.convert_to_tensor(reshape_img, dtype=tf.float32)
 
 # load model
-module = hub.load("https://tfhub.dev/intel/midas/v2_1/2", tags=['serve'])
+module = hub.load("https://tfhub.dev/intel/midas/v2_1_small/1", tags=['serve'])
 output = module.signatures['serving_default'](tensor)
 prediction = output['default'].numpy()
 prediction = prediction.reshape(256, 256)
@@ -75,7 +76,10 @@ print(" Write image to: output.png")
 depth_min = prediction.min()
 depth_max = prediction.max()
 img_out = (255 * (prediction - depth_min) / (depth_max - depth_min)).astype("uint8")
+
 cv2.imwrite("output.png", img_out)
+plt.imshow(img_out)
+# plt.show()
 
 ```
 

--- a/assets/docs/intel/midas/v2_1_small/1/lite/1.md
+++ b/assets/docs/intel/midas/v2_1_small/1/lite/1.md
@@ -1,0 +1,90 @@
+# Lite intel/midas/v2_1_small/1/lite/1
+A deployment format of Lite intel/midas/v2_1_small/1
+
+<!-- asset-path: https://github.com/intel-isl/MiDaS/releases/download/v2_1/model_opt.tflite -->
+<!-- module-type: image-depth-estimation -->
+<!-- parent-model: intel/midas/v2_1_small/1 -->
+<!-- network-architecture: MiDaS -->
+<!-- dataset: DIML Indoor, MegaDepth, ReDWeb, WSVD, 3D Movies, TartanAir, HRWSI, ApolloScape, BlendedMVS, IRS -->
+<!-- fine-tunable: false  -->
+<!-- license: MIT -->
+
+
+## License
+MIT License
+
+#### Inference speed
+
+Mobile real-time convolutional neural network for monocular depth estimation from a single RGB image:
+
+* iOS 13.7 - iPhone11 (A13 Bionic) - 30 FPS on NPU
+* Andoird 10 - OnePlus8 (Snapdragon 865) - 22 FPS on GPU
+
+#### Requirements
+
+* iOS: [iOS application](https://github.com/intel-isl/MiDaS/tree/master/mobile/ios)
+* Android: [Android application](https://github.com/intel-isl/MiDaS/tree/master/mobile/android)
+* CPU or nVidia GPU:
+
+```
+pip install tensorflow opencv-python
+```
+
+
+#### Model Details
+This module is based on a Pytorch version of MiDaS, which performs efficiently and with very high accuracy to compute depth from a single image.
+
+* input: (uint8) RGB image with shape (3, 256, 256)
+* output: (float32) inverse depth maps (1, 256, 256)
+
+#### Example Use
+
+```python
+import cv2
+import tensorflow as tf
+import urllib.request
+
+url, filename = ("https://github.com/intel-isl/MiDaS/releases/download/v2/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+
+url, filename = ("https://github.com/intel-isl/MiDaS/releases/download/v2_1/model_opt.tflite", "model_opt.tflite")
+urllib.request.urlretrieve(url, filename)
+
+
+# input
+img = cv2.imread('dog.jpg')
+img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) / 255.0
+
+img_resized = tf.image.resize(img, [256,256], method='bicubic', preserve_aspect_ratio=False)
+#img_resized = tf.transpose(img_resized, [2, 0, 1])
+img_input = img_resized.numpy()
+mean=[0.485, 0.456, 0.406]
+std=[0.229, 0.224, 0.225]
+img_input = (img_input - mean) / std
+reshape_img = img_input.reshape(1,256,256,3)
+tensor = tf.convert_to_tensor(reshape_img, dtype=tf.float32)
+
+# load model
+interpreter = tf.lite.Interpreter(model_path="model_opt.tflite")
+interpreter.allocate_tensors()
+input_details = interpreter.get_input_details()
+output_details = interpreter.get_output_details()
+input_shape = input_details[0]['shape']
+
+# inference
+interpreter.set_tensor(input_details[0]['index'], tensor)
+interpreter.invoke()
+output = interpreter.get_tensor(output_details[0]['index'])
+output = output.reshape(256, 256)
+             
+# output file
+prediction = cv2.resize(output, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_CUBIC)
+print(" Write image to: output.png")
+depth_min = prediction.min()
+depth_max = prediction.max()
+img_out = (255 * (prediction - depth_min) / (depth_max - depth_min)).astype("uint8")
+cv2.imwrite("output.png", img_out)
+```
+
+
+**Source:** https://github.com/intel-isl/MiDaS

--- a/assets/docs/intel/midas/v2_1_small/1/lite/1.md
+++ b/assets/docs/intel/midas/v2_1_small/1/lite/1.md
@@ -27,7 +27,7 @@ Mobile real-time convolutional neural network for monocular depth estimation fro
 * CPU or nVidia GPU:
 
 ```
-pip install tensorflow opencv-python
+pip install tensorflow opencv-python matplotlib
 ```
 
 
@@ -43,6 +43,7 @@ This module is based on a Pytorch version of MiDaS, which performs efficiently a
 import cv2
 import tensorflow as tf
 import urllib.request
+import matplotlib.pyplot as plt
 
 url, filename = ("https://github.com/intel-isl/MiDaS/releases/download/v2/dog.jpg", "dog.jpg")
 urllib.request.urlretrieve(url, filename)
@@ -83,7 +84,10 @@ print(" Write image to: output.png")
 depth_min = prediction.min()
 depth_max = prediction.max()
 img_out = (255 * (prediction - depth_min) / (depth_max - depth_min)).astype("uint8")
+
 cv2.imwrite("output.png", img_out)
+plt.imshow(img_out)
+# plt.show()
 ```
 
 


### PR DESCRIPTION
Fix URL for hub.load() for new MiDaS models from PR: https://github.com/tensorflow/tfhub.dev/pull/16
It seems I forgot to change the paths in the examples when I fixed the paths to the models.

