### PR TITLE
Add monatis as a publisher, publish German Tacotron 2 and MB MelGAN

### DIFF
--- a/assets/docs/monatis/models/german-mbmelgan/1.md
+++ b/assets/docs/monatis/models/german-mbmelgan/1.md
@@ -2,7 +2,7 @@
 German Multi-band MelGAN as described in [1].
 
 <!-- asset-path: https://storage.googleapis.com/mys-released-models/german-tts-mbmelgan.tar.gz -->
-<!-- module-type: mel-to-speech -->
+<!-- module-type: audio-synthesis -->
 <!-- network-architecture: multiband-melgan -->
 <!-- dataset: thorsten -->
 <!-- language: de -->

--- a/assets/docs/monatis/models/german-mbmelgan/1.md
+++ b/assets/docs/monatis/models/german-mbmelgan/1.md
@@ -1,0 +1,24 @@
+# Module monatis/german-mbmelgan/1
+German Multi-band MelGAN as described in [1].
+
+<!-- asset-path: https://storage.googleapis.com/mys-released-models/german-tts-mbmelgan.tar.gz -->
+<!-- module-type: mel-to-speech -->
+<!-- network-architecture: multiband-melgan -->
+<!-- dataset: thorsten -->
+<!-- language: de -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+<!-- license: Apache-2.0 -->
+
+## Overview
+This is a mel-to-speech model to be used for neural text-to-speech synthesis. You need a text-to-mel model, e.g. Tacotron 2 (also published on TF Hub), to get MEL spectagrams first. See [monatis/german-tts](https://github.com/monatis/german-tts) repo on GitHub for an end-to-end inference example.
+
+## Dataset
+I trained these models on [Thorsten dataset](https://github.com/thorstenMueller/deep-learning-german-tts) by Thorsten Müller. It is licensed under the terms of Creative Commons Zero V1 Universal (CC0), which is used to opt out of copyright entirely and ensure that the work has the widest reach. Thanks [@thorstenMueller](https://github.com/thorstenMueller) for such a great contribution to the community.
+
+## Notes
+- I made use of [german_transliterate](https://github.com/repodiac/german_transliterate) For text preprocessing. Basically it normalizes numbers (e.g. converts digits to words), expands abbreviations and cares German umlauts and punctuations. For inference examples released in this repo, it is the only dependency apart from TensorFlow.
+- You need to convert input text to numerical IDs to feed into the model. I am sharing a reference implementation for this in inference examples, and you need to code this logic to use the models in non-Python environments (e.g., Android).
+
+#### References
+[1] Geng Yang, Shan Yang, Kai Liu, Peng Fang, Wei Chen, Lei Xie. Multi-band MelGAN: Faster Waveform Generation for High-Quality Text-to-Speech. https://arxiv.org/abs/2005.05106

--- a/assets/docs/monatis/models/german-mbmelgan/lite/1.md
+++ b/assets/docs/monatis/models/german-mbmelgan/lite/1.md
@@ -1,0 +1,25 @@
+# Lite monatis/german-mbmelgan/lite/1
+TF Lite version of German Multi-band MelGAN as described in [1].
+
+<!-- parent-model monatis/german-mbmelgan/1 -->
+<!-- asset-path: https://storage.googleapis.com/mys-released-models/german-tts-mbmelgan-lite.tar.gz -->
+<!-- module-type: mel-to-speech -->
+<!-- network-architecture: multiband-melgan -->
+<!-- dataset: thorsten -->
+<!-- language: de -->
+<!-- fine-tunable: false -->
+<!-- license: Apache-2.0 -->
+
+## Overview
+This is the TF Lite version of German Multi-band MelGAN to be used with TF Lite library. It is a mel-to-speech model to be used for neural text-to-speech synthesis, and You need a text-to-mel model, e.g. Tacotron 2 (also published on TF Hub), to get MEL spectagrams first. See [monatis/german-tts](https://github.com/monatis/german-tts) repo on GitHub for an end-to-end inference example.
+
+## Dataset
+I trained these models on [Thorsten dataset](https://github.com/thorstenMueller/deep-learning-german-tts) by Thorsten Müller. It is licensed under the terms of Creative Commons Zero V1 Universal (CC0), which is used to opt out of copyright entirely and ensure that the work has the widest reach. Thanks [@thorstenMueller](https://github.com/thorstenMueller) for such a great contribution to the community.
+
+## Notes
+- I made use of [german_transliterate](https://github.com/repodiac/german_transliterate) For text preprocessing. Basically it normalizes numbers (e.g. converts digits to words), expands abbreviations and cares German umlauts and punctuations. For inference examples released in this repo, it is the only dependency apart from TensorFlow.
+- You need to convert input text to numerical IDs to feed into the model. I am sharing a reference implementation for this in inference examples, and you need to code this logic to use the models in non-Python environments (e.g., Android).
+- I exported Multi-band MelGAN to TF Lite without optimizations because it produced some background noise when I exported with the default ones. 
+
+#### References
+[1] Geng Yang, Shan Yang, Kai Liu, Peng Fang, Wei Chen, Lei Xie. Multi-band MelGAN: Faster Waveform Generation for High-Quality Text-to-Speech. https://arxiv.org/abs/2005.05106

--- a/assets/docs/monatis/models/german-mbmelgan/lite/1.md
+++ b/assets/docs/monatis/models/german-mbmelgan/lite/1.md
@@ -3,7 +3,7 @@ TF Lite version of German Multi-band MelGAN as described in [1].
 
 <!-- parent-model monatis/german-mbmelgan/1 -->
 <!-- asset-path: https://storage.googleapis.com/mys-released-models/german-tts-mbmelgan-lite.tar.gz -->
-<!-- module-type: mel-to-speech -->
+<!-- module-type: audio-synthesis -->
 <!-- network-architecture: multiband-melgan -->
 <!-- dataset: thorsten -->
 <!-- language: de -->

--- a/assets/docs/monatis/models/german-mbmelgan/lite/1.md
+++ b/assets/docs/monatis/models/german-mbmelgan/lite/1.md
@@ -1,7 +1,7 @@
 # Lite monatis/german-mbmelgan/lite/1
 TF Lite version of German Multi-band MelGAN as described in [1].
 
-<!-- parent-model monatis/german-mbmelgan/1 -->
+<!-- parent-model: monatis/german-mbmelgan/1 -->
 <!-- asset-path: https://storage.googleapis.com/mys-released-models/german-tts-mbmelgan-lite.tar.gz -->
 <!-- module-type: audio-synthesis -->
 <!-- network-architecture: multiband-melgan -->

--- a/assets/docs/monatis/models/german-tacotron2/1.md
+++ b/assets/docs/monatis/models/german-tacotron2/1.md
@@ -1,0 +1,26 @@
+# Module monatis/german-tacotron2/1
+German Tacotron 2 as described in [1].
+
+<!-- asset-path: https://storage.googleapis.com/mys-released-models/german-tts-tacotron2.tar.gz -->
+<!-- module-type: text-to-mel -->
+<!-- network-architecture: tacotron2 -->
+<!-- dataset: thorsten -->
+<!-- language: de -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+<!-- license: Apache-2.0 -->
+
+## Overview
+This is a text-to-mel model to be used for neural text-to-speech synthesis. You need a vocoder, e.g. Multi-band MelGAN (also published on TF Hub), to synthesize actual audio. See [monatis/german-tts](https://github.com/monatis/german-tts) repo on GitHub for an end-to-end inference example.
+
+## Dataset
+I trained these models on [Thorsten dataset](https://github.com/thorstenMueller/deep-learning-german-tts) by Thorsten Müller. It is licensed under the terms of Creative Commons Zero V1 Universal (CC0), which is used to opt out of copyright entirely and ensure that the work has the widest reach. Thanks [@thorstenMueller](https://github.com/thorstenMueller) for such a great contribution to the community.
+
+## Notes
+- I made use of [german_transliterate](https://github.com/repodiac/german_transliterate) For text preprocessing. Basically it normalizes numbers (e.g. converts digits to words), expands abbreviations and cares German umlauts and punctuations. For inference examples released in this repo, it is the only dependency apart from TensorFlow.
+- You need to convert input text to numerical IDs to feed into the model. I am sharing a reference implementation for this in inference examples, and you need to code this logic to use the models in non-Python environments (e.g., Android).
+- `Tacotron 2` produces some noise at the end, and you need to cut it off. Again, inference examples show how to do this.
+- `saved_model` formats that I am releasing here are not suitable for finetuning. Architecture implementation uses `Subclassing API` in TensorFlow 2.x and gets multiple inputs in `call` method for teacher forcing during training. This caused some problems when exporting to `saved_model` and I had to remove this logic before exporting. If you want to finetune models, please see [my fork of TensorFlowTTS](https://github.com/monatis/TensorFlowTTS).
+
+#### References
+[1] Jonathan Shen, Ruoming Pang, Ron J. Weiss, Mike Schuster, Navdeep Jaitly, Zongheng Yang, Zhifeng Chen, Yu Zhang, Yuxuan Wang, RJ Skerr-Ryan, Rif A. Saurous, Yannis Agiomyrgiannakis, Yonghui Wu. Natural TTS Synthesis by Conditioning WaveNet on Mel Spectrogram Predictions. https://arxiv.org/abs/1712.05884

--- a/assets/docs/monatis/models/german-tacotron2/lite/1.md
+++ b/assets/docs/monatis/models/german-tacotron2/lite/1.md
@@ -1,0 +1,25 @@
+# Lite monatis/german-tacotron2/lite/1
+TF Lite version of German Tacotron 2 as described in [1].
+
+<!-- parent-model: monatis/german-tacotron2/1 -->
+<!-- asset-path: https://storage.googleapis.com/mys-released-models/german-tts-tacotron2-lite.tar.gz -->
+<!-- module-type: text-to-mel -->
+<!-- network-architecture: tacotron2 -->
+<!-- dataset: thorsten -->
+<!-- language: de -->
+<!-- fine-tunable: false -->
+<!-- license: Apache-2.0 -->
+
+## Overview
+This is the TF Lite version of German Tacotron 2 to be used with TF Lite library. It is a text-to-mel model, and you need a vocoder, e.g. Multi-band MelGAN (also published on TF Hub), to synthesize actual audio. See [monatis/german-tts](https://github.com/monatis/german-tts) repo on GitHub for an end-to-end inference example.
+
+## Dataset
+I trained these models on [Thorsten dataset](https://github.com/thorstenMueller/deep-learning-german-tts) by Thorsten Müller. It is licensed under the terms of Creative Commons Zero V1 Universal (CC0), which is used to opt out of copyright entirely and ensure that the work has the widest reach. Thanks [@thorstenMueller](https://github.com/thorstenMueller) for such a great contribution to the community.
+
+## Notes
+- I made use of [german_transliterate](https://github.com/repodiac/german_transliterate) For text preprocessing. Basically it normalizes numbers (e.g. converts digits to words), expands abbreviations and cares German umlauts and punctuations. For inference examples released in this repo, it is the only dependency apart from TensorFlow.
+- You need to convert input text to numerical IDs to feed into the model. I am sharing a reference implementation for this in inference examples, and you need to code this logic to use the models in non-Python environments (e.g., Android).
+- `Tacotron 2` produces some noise at the end, and you need to cut it off. Again, inference examples show how to do this.
+
+#### References
+[1] Jonathan Shen, Ruoming Pang, Ron J. Weiss, Mike Schuster, Navdeep Jaitly, Zongheng Yang, Zhifeng Chen, Yu Zhang, Yuxuan Wang, RJ Skerr-Ryan, Rif A. Saurous, Yannis Agiomyrgiannakis, Yonghui Wu. Natural TTS Synthesis by Conditioning WaveNet on Mel Spectrogram Predictions. https://arxiv.org/abs/1712.05884

--- a/assets/docs/monatis/monatis.md
+++ b/assets/docs/monatis/monatis.md
@@ -1,0 +1,13 @@
+# Publisher monatis
+M. Yusuf Sarıgöz
+
+[![Icon URL]](https://avatars3.githubusercontent.com/u/18634956?s=400&u=8ac102cb25c2b96f6a11edb1702bc9485fc40a2f&v=4)
+
+## Details
+M. Yusuf Sarıgöz ([<yusufsarigoz@gmail.com>](mailto:yusufsarigoz@gmail.com).
+AI Researcher at [AI Labs](https://ailabs.com.tr).
+Google Developer Expert in Machine Learning.
+Scientific Committee Member at CDOSS
+
+- [Github @monatis](https://github.com/monatis)
+- [LinkedIn](https://www.linkedin.com/in/yusuf-sar%C4%B1g%C3%B6z-4bb826ba/)


### PR DESCRIPTION
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms.
Publishing both saved_model and TF Lite versions of Tacotron 2 and Multi-band MelGAN In German I trained.