### PR TITLE
Adding the MIRNet model

### DIFF
--- a/assets/docs/sayakpaul/mirnet-fixed/1.md
+++ b/assets/docs/sayakpaul/mirnet-fixed/1.md
@@ -1,0 +1,8 @@
+# Placeholder sayakpaul/mirnet-fixed/1
+MIRNet model to enhance a low-light image.
+
+<!-- dataset: LOL -->
+<!-- module-type: image-super-resolution -->
+<!-- network-architecture: Other -->
+<!-- fine-tunable: false -->
+<!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/mirnet-fixed/dr/1.md
+++ b/assets/docs/sayakpaul/mirnet-fixed/dr/1.md
@@ -1,0 +1,25 @@
+# Lite sayakpaul/mirnet-fixed/dr/1
+TF Lite quantized version of the MIRNet model to enhance a low-light image.
+
+<!-- parent-model: sayakpaul/mirnet-fixed/1 -->
+<!-- asset-path: https://github.com/sayakpaul/MIRNet-TFLite/releases/download/v0.3.0/mirnet_dr.tar.gz -->
+
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/MIRNet-TFLite/blob/main/MIRNet_TFLite_Fixed_Shape.ipynb)
+
+### Overview
+The MIRNet model is proposed in [1]. The model can take a low-light image and enhance it to a great extent. Here is an example result -
+
+![](https://i.ibb.co/n61wCD2/download.png)
+
+### Note
+- This model was quantized using _dynamic range quantization_ as described [here](https://www.tensorflow.org/lite/performance/post_training_quant).
+- This model is populated with metadata.
+- This model takes fixed-shaped (400x400) inputs (images with RGB channel ordering).
+- The Colab Notebook that accompanies the model contains conversion and inference steps.
+
+### Acknowledgements
+Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet). Thanks to Khanh LeViet for helping to verify the metadata population.
+
+References
+--------------
+[1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ECCV 2020, https://arxiv.org/abs/2003.06792.

--- a/assets/docs/sayakpaul/mirnet-fixed/fp16/1.md
+++ b/assets/docs/sayakpaul/mirnet-fixed/fp16/1.md
@@ -1,0 +1,25 @@
+# Lite sayakpaul/mirnet-fixed/fp16/1
+TF Lite quantized version of the MIRNet model to enhance a low-light image.
+
+<!-- parent-model: sayakpaul/mirnet-fixed/1 -->
+<!-- asset-path: https://github.com/sayakpaul/MIRNet-TFLite/releases/download/v0.3.0/mirnet_fp16.tar.gz -->
+
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/MIRNet-TFLite/blob/main/MIRNet_TFLite_Fixed_Shape.ipynb)
+
+### Overview
+The MIRNet model is proposed in [1]. The model can take a low-light image and enhance it to a great extent. Here is an example result -
+
+![](https://i.ibb.co/n61wCD2/download.png)
+
+### Note
+- This model was quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This model is populated with metadata.
+- This model takes fixed-shaped (400x400) inputs (images with RGB channel ordering).
+- The Colab Notebook that accompanies the model contains conversion and inference steps.
+
+### Acknowledgements
+Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet). Thanks to Khanh LeViet for helping to verify the metadata population.
+
+References
+--------------
+[1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ECCV 2020, https://arxiv.org/abs/2003.06792.

--- a/assets/docs/sayakpaul/mirnet-fixed/integer/1.md
+++ b/assets/docs/sayakpaul/mirnet-fixed/integer/1.md
@@ -1,0 +1,25 @@
+# Lite sayakpaul/mirnet-fixed/integer/1
+TF Lite quantized version of the MIRNet model to enhance a low-light image.
+
+<!-- parent-model: sayakpaul/mirnet-fixed/1 -->
+<!-- asset-path: https://github.com/sayakpaul/MIRNet-TFLite/releases/download/v0.3.0/mirnet_int8.tar.gz -->
+
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/MIRNet-TFLite/blob/main/MIRNet_TFLite_Fixed_Shape.ipynb)
+
+### Overview
+The MIRNet model is proposed in [1]. The model can take a low-light image and enhance it to a great extent. Here is an example result -
+
+![](https://i.ibb.co/n61wCD2/download.png)
+
+### Note
+- This model was quantized using `integer` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_integer_quant).
+- This model is populated with metadata.
+- This model takes fixed-shaped (400x400) inputs (images with RGB channel ordering).
+- The Colab Notebook that accompanies the model contains conversion and inference steps.
+
+### Acknowledgements
+Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet). Thanks to Khanh LeViet for helping to verify the metadata population.
+
+References
+--------------
+[1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ECCV 2020, https://arxiv.org/abs/2003.06792.


### PR DESCRIPTION
TensorFlow Lite models for low-light image enhancement. The model is proposed in [1]. Original model weights are used from [2]. 

[1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ECCV 2020, https://arxiv.org/abs/2003.06792.
[2] https://github.com/soumik12345/MIRNet