### PR TITLE
Add MIRNet TFJS Models

### DIFF
--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -9,3 +9,6 @@ MIRNet model to enhance a low-light images.
 <!-- license: Apache-2.0 -->
 <!-- format: saved_model_2 -->
 <!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.1.0/saved-model.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -10,6 +10,8 @@ MIRNet model to enhance a low-light images.
 <!-- format: saved_model_2 -->
 <!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.1.0/saved-model.tar.gz -->
 
+[![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_Saved_Model.ipynb)
+
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -1,5 +1,4 @@
 # Placeholder rishit-dagli/mirnet-tfjs/1
-
 MIRNet model to enhance a low-light images.
 
 <!-- module-type: image-super-resolution -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -7,7 +7,7 @@ MIRNet model to enhance a low-light images.
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.1.0/saved-model.tar.gz -->
+<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/saved_model.tar.gz -->
 
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_Saved_Model.ipynb)
 

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -1,4 +1,4 @@
-Placeholder rishit-dagli/mirnet-tfjs/1
+# Placeholder rishit-dagli/mirnet-tfjs/1
 
 MIRNet model to enhance a low-light images.
 

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -3,7 +3,7 @@ MIRNet model to enhance a low-light images.
 
 <!-- module-type: image-super-resolution -->
 <!-- network-architecture: other -->
-<!-- dataset: lol -->
+<!-- dataset: LOL -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->
 <!-- format: saved_model_2 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -18,6 +18,9 @@ The MIRNet model proposed in Learning Enriched Features for Real Image Restorati
 
 ![](https://i.imgur.com/58VzXAO.png)
 
+### Acknowledgements
+Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet).
+
 ### References
 
 [1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ArXiv:2003.06792 [Cs], July 2020. arXiv.org, https://arxiv.org/abs/2003.06792.

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -17,7 +17,7 @@ This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here are a couple of result -
 
-![](https://i.imgur.com/DAsqeFC.jpg)
+![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
 
 ### Acknowledgements
 Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet).

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -12,3 +12,8 @@ MIRNet model to enhance a low-light images.
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.). The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
+
+![](https://i.imgur.com/58VzXAO.png)

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -14,6 +14,10 @@ MIRNet model to enhance a low-light images.
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
 ### Overview
-The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.). The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
+The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
 ![](https://i.imgur.com/58VzXAO.png)
+
+### References
+
+[1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ArXiv:2003.06792 [Cs], July 2020. arXiv.org, https://arxiv.org/abs/2003.06792.

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -1,0 +1,11 @@
+Placeholder rishit-dagli/mirnet-tfjs/1
+
+MIRNet model to enhance a low-light images.
+
+<!-- module-type: image-super-resolution -->
+<!-- network-architecture: other -->
+<!-- dataset: lol -->
+<!-- fine-tunable: false -->
+<!-- license: Apache-2.0 -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.1.0/saved-model.tar.gz -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -1,4 +1,4 @@
-# Placeholder rishit-dagli/mirnet-tfjs/1
+# Module rishit-dagli/mirnet-tfjs/1
 MIRNet model to enhance a low-light images.
 
 <!-- module-type: image-super-resolution -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
@@ -1,9 +1,9 @@
 # Tfjs rishit-dagli/mirnet-tfjs/default/lite/no-comp/1
 
-No compression TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
+FP16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->
-<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_no_comp.tar.gz -->
+<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_float_!6.tar.gz -->
 
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
 
@@ -22,7 +22,7 @@ Example use
 This model can be loaded using TF.js as:
 
 ```js
-tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1", { fromTFHub: true })
+tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/fp16/1", { fromTFHub: true })
 ```
 
 ### Acknowledgements

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
@@ -14,7 +14,7 @@ This model has been automatically converted using the [TF.js converter](https://
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
-![](https://i.imgur.com/58VzXAO.png)
+![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
 
 ### Example use
 Example use

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
@@ -1,9 +1,9 @@
-# Tfjs rishit-dagli/mirnet-tfjs/default/lite/no-comp/1
+# Tfjs rishit-dagli/mirnet-tfjs/default/lite/fp16/1
 
 FP16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->
-<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_float_!6.tar.gz -->
+<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_float_16.tar.gz -->
 
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
 

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
@@ -1,4 +1,4 @@
-# Tfjs rishit-dagli/mirnet-tfjs/default/lite/fp16/1
+# Tfjs rishit-dagli/mirnet-tfjs/default/fp16/1
 FP16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
@@ -21,7 +21,7 @@ Example use
 This model can be loaded using TF.js as:
 
 ```js
-tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/fp16/1", { fromTFHub: true })
+tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/fp16/1", { fromTFHub: true })
 ```
 
 ### Acknowledgements

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
@@ -8,7 +8,7 @@ FP16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
 
 ### Origin
-This model is based on [rishit-dagli/chest-xray-covid/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
+This model is based on [rishit-dagli/mirnet-tfjs/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
 
 This model has been automatically converted using the [TF.js converter](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter).
 

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
@@ -1,5 +1,4 @@
 # Tfjs rishit-dagli/mirnet-tfjs/default/lite/fp16/1
-
 FP16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -1,4 +1,4 @@
-# Tfjs rishit-dagli/mirnet-tfjs/default/lite/no-comp/1
+# Tfjs rishit-dagli/mirnet-tfjs/default/no-comp/1
 No compression TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -14,7 +14,7 @@ This model has been automatically converted using the [TF.js converter](https://
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
-![](https://i.imgur.com/58VzXAO.png)
+![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
 
 ### Example use
 Example use

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -3,4 +3,4 @@
 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->
-<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_float_16.tar.gz -->
+<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_no_comp.tar.gz -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -1,6 +1,6 @@
 # Tfjs rishit-dagli/mirnet-tfjs/default/lite/no-comp/1
 
-TF.js deployment of rishit-dagli/chest-xray-covid/1 .
+TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->
 <!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_float_16.tar.gz -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -4,3 +4,5 @@ TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->
 <!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_no_comp.tar.gz -->
+
+[![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -8,7 +8,7 @@ No compression TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
 
 ### Origin
-This model is based on [rishit-dagli/chest-xray-covid/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
+This model is based on [rishit-dagli/mirnet-tfjs/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
 
 This model has been automatically converted using the [TF.js converter](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter).
 

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -21,7 +21,7 @@ Example use
 This model can be loaded using TF.js as:
 
 ```js
-tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1", { fromTFHub: true })
+tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/no-comp/1", { fromTFHub: true })
 ```
 
 ### Acknowledgements

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -7,10 +7,23 @@ TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
 
+### Origin
+This model is based on [rishit-dagli/chest-xray-covid/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
+
+This model has been automatically converted using the [TF.js converter](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter).
+
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
 ![](https://i.imgur.com/58VzXAO.png)
+
+### Example use
+Example use
+This model can be loaded using TF.js as:
+
+```js
+tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1", { fromTFHub: true })
+```
 
 ### Acknowledgements
 Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet).

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -1,5 +1,4 @@
 # Tfjs rishit-dagli/mirnet-tfjs/default/lite/no-comp/1
-
 No compression TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -1,0 +1,6 @@
+# Tfjs rishit-dagli/mirnet-tfjs/default/lite/no-comp/1
+
+TF.js deployment of rishit-dagli/chest-xray-covid/1 .
+
+<!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->
+<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_float_16.tar.gz -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -6,3 +6,15 @@ TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 <!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_no_comp.tar.gz -->
 
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
+
+### Overview
+The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
+
+![](https://i.imgur.com/58VzXAO.png)
+
+### Acknowledgements
+Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet).
+
+### References
+
+[1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ArXiv:2003.06792 [Cs], July 2020. arXiv.org, https://arxiv.org/abs/2003.06792.

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
@@ -14,7 +14,7 @@ This model has been automatically converted using the [TF.js converter](https://
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
-![](https://i.imgur.com/58VzXAO.png)
+![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
 
 ### Example use
 Example use

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
@@ -8,7 +8,7 @@ UINT16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
 
 ### Origin
-This model is based on [rishit-dagli/chest-xray-covid/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
+This model is based on [rishit-dagli/mirnet-tfjs/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
 
 This model has been automatically converted using the [TF.js converter](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter).
 

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
@@ -21,7 +21,7 @@ Example use
 This model can be loaded using TF.js as:
 
 ```js
-tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/uint16/1", { fromTFHub: true })
+tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/uint16/1", { fromTFHub: true })
 ```
 
 ### Acknowledgements

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
@@ -1,0 +1,33 @@
+# Tfjs rishit-dagli/mirnet-tfjs/default/lite/uint16/1
+
+UINT16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
+
+<!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->
+<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_uint_16.tar.gz -->
+
+[![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
+
+### Origin
+This model is based on [rishit-dagli/chest-xray-covid/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
+
+This model has been automatically converted using the [TF.js converter](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter).
+
+### Overview
+The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
+
+![](https://i.imgur.com/58VzXAO.png)
+
+### Example use
+Example use
+This model can be loaded using TF.js as:
+
+```js
+tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/uint16/1", { fromTFHub: true })
+```
+
+### Acknowledgements
+Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet).
+
+### References
+
+[1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ArXiv:2003.06792 [Cs], July 2020. arXiv.org, https://arxiv.org/abs/2003.06792.

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
@@ -1,5 +1,4 @@
 # Tfjs rishit-dagli/mirnet-tfjs/default/lite/uint16/1
-
 UINT16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
@@ -1,4 +1,4 @@
-# Tfjs rishit-dagli/mirnet-tfjs/default/lite/uint16/1
+# Tfjs rishit-dagli/mirnet-tfjs/default/uint16/1
 UINT16 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
@@ -1,4 +1,4 @@
-# Tfjs rishit-dagli/mirnet-tfjs/default/lite/uint8/1
+# Tfjs rishit-dagli/mirnet-tfjs/default/uint8/1
 UINT8 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
@@ -14,7 +14,7 @@ This model has been automatically converted using the [TF.js converter](https://
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
-![](https://i.imgur.com/58VzXAO.png)
+![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
 
 ### Example use
 Example use

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
@@ -21,7 +21,7 @@ Example use
 This model can be loaded using TF.js as:
 
 ```js
-tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/uint8/1", { fromTFHub: true })
+tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/uint8/1", { fromTFHub: true })
 ```
 
 ### Acknowledgements

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
@@ -8,7 +8,7 @@ UINT8 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 [![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
 
 ### Origin
-This model is based on [rishit-dagli/chest-xray-covid/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
+This model is based on [rishit-dagli/mirnet-tfjs/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
 
 This model has been automatically converted using the [TF.js converter](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter).
 

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
@@ -1,5 +1,4 @@
 # Tfjs rishit-dagli/mirnet-tfjs/default/lite/uint8/1
-
 UINT8 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
 
 <!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
@@ -1,0 +1,33 @@
+# Tfjs rishit-dagli/mirnet-tfjs/default/lite/uint8/1
+
+UINT8 TF.js deployment of rishit-dagli/mirnet-tfjs/1 .
+
+<!-- parent-model: rishit-dagli/mirnet-tfjs/1 -->
+<!-- asset-path: https://github.com/Rishit-dagli/MIRNet-TFJS/releases/download/v0.2.0/mirnet_uint_8.tar.gz -->
+
+[![Open Colab notebook]](https://colab.research.google.com/github/Rishit-dagli/MIRNet-TFJS/blob/main/MIRNet_TFJS.ipynb)
+
+### Origin
+This model is based on [rishit-dagli/chest-xray-covid/1](https://tfhub.dev/rishit-dagli/mirnet-tfjs/1/).
+
+This model has been automatically converted using the [TF.js converter](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter).
+
+### Overview
+The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
+
+![](https://i.imgur.com/58VzXAO.png)
+
+### Example use
+Example use
+This model can be loaded using TF.js as:
+
+```js
+tf.loadGraphModel("https://tfhub.dev/rishit-dagli/mirnet-tfjs/default/lite/uint8/1", { fromTFHub: true })
+```
+
+### Acknowledgements
+Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet).
+
+### References
+
+[1] Learning Enriched Features for Real Image Restoration and Enhancement. Syed Waqas Zamir, Aditya Arora, Salman Khan, Munawar Hayat, Fahad Shahbaz Khan, Ming-Hsuan Yang, and Ling Shao; ArXiv:2003.06792 [Cs], July 2020. arXiv.org, https://arxiv.org/abs/2003.06792.


### PR DESCRIPTION
Add TFJS version of MIRNet model as proposed by [Learning Enriched Features for Real Image Restoration and Enhancement](https://arxiv.org/pdf/2003.06792v2.pdf) by Zamir et al.  This model is capable of enhancing low-light images upto a great extent.

I also request you to kindly take a look at the headings for the TFJS models, I found that the docs were not very clear so as to what should be entered there for multiple models

---
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms.
