### PR TITLE
Update mirnet image url to raw.githubusercontent...

### DIFF
--- a/assets/docs/rishit-dagli/mirnet-tfjs/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/1.md
@@ -17,7 +17,7 @@ This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here are a couple of result -
 
-![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
+![](https://raw.githubusercontent.com/Rishit-dagli/MIRNet-TFJS/main/images/mirnet-results.jpg)
 
 ### Acknowledgements
 Soumik trained the original model that was used for generating the TensorFlow Lite models. Soumik's code repository is available [here](https://github.com/soumik12345/MIRNet).

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/fp16/1.md
@@ -14,7 +14,7 @@ This model has been automatically converted using the [TF.js converter](https://
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
-![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
+![](https://raw.githubusercontent.com/Rishit-dagli/MIRNet-TFJS/main/images/mirnet-results.jpg)
 
 ### Example use
 Example use

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/no-comp/1.md
@@ -14,7 +14,7 @@ This model has been automatically converted using the [TF.js converter](https://
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
-![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
+![](https://raw.githubusercontent.com/Rishit-dagli/MIRNet-TFJS/main/images/mirnet-results.jpg)
 
 ### Example use
 Example use

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint16/1.md
@@ -14,7 +14,7 @@ This model has been automatically converted using the [TF.js converter](https://
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
-![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
+![](https://raw.githubusercontent.com/Rishit-dagli/MIRNet-TFJS/main/images/mirnet-results.jpg)
 
 ### Example use
 Example use

--- a/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
+++ b/assets/docs/rishit-dagli/mirnet-tfjs/default/lite/uint8/1.md
@@ -14,7 +14,7 @@ This model has been automatically converted using the [TF.js converter](https://
 ### Overview
 The MIRNet model proposed in Learning Enriched Features for Real Image Restoration and Enhancement (Zamir et al.) [1] . The model can take a low-light image and enhance it to a great extent. The model has goals of maintaining high-resolution representations through the entire network, and receiving strong contextual information from the low-resolution representations. Here is an example result -
 
-![](https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg)
+![](https://raw.githubusercontent.com/Rishit-dagli/MIRNet-TFJS/main/images/mirnet-results.jpg)
 
 ### Example use
 Example use


### PR DESCRIPTION
The current url (https://github.com/Rishit-dagli/MIRNet-TFJS/blob/main/images/mirnet-results.jpg) returns an HTML site. Interestingly, the preview on GitHub renders it correctly as an image. However, the actual url of the image (https://raw.githubusercontent.com/Rishit-dagli/MIRNet-TFJS/main/images/mirnet-results.jpg) should work on more platforms.