### PR TITLE
Update documentation to showcase proper TF2 usage for bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1

### DIFF
--- a/assets/docs/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1.md
+++ b/assets/docs/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1.md
@@ -28,10 +28,15 @@ This model takes input of images.
 The model can be loaded in a Python script as follows:
 
 ```python
-module = hub.Module("https://tfhub.dev/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1")
-height, width = hub.get_expected_image_size(module)
-images = ...  # A batch of images with shape [batch_size, height, width, 3].
-output_dict = module(images)  # Output dictionary.
+model = hub.load("https://tfhub.dev/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1")
+
+@tf.function(input_signature=[tf.TensorSpec(shape=[None, None, None, 3], dtype=tf.float32)])
+def call_model(image_tensor):
+  output_dict = module.signatures["serving_default"](image_tensor)
+  return output_dict['out']
+  
+images = ...  # A batch of images with shape [batch_size, 360, 360, 3].
+output_dict = call_model(images)  # Output dictionary.
 ```
 
 ### License

--- a/assets/docs/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1.md
+++ b/assets/docs/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1.md
@@ -35,7 +35,7 @@ def call_model(image_tensor):
   output_dict = module.signatures["serving_default"](image_tensor)
   return output_dict['out']
   
-images = ...  # A batch of images with shape [batch_size, 360, 360, 3].
+images = ...  # A batch of images with shape [batch_size, height, width, 3].
 output_dict = call_model(images)  # Output dictionary.
 ```
 


### PR DESCRIPTION
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms.
