### PR TITLE
VGG19 encoder-decoder pairs using unpooling layers

### DIFF
--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -32,15 +32,15 @@ Encoder inputs are expected to be batches of images of arbitrary height and widt
 
 | Name | Input Shape | Output Shape | L1 loss* |
 |--|--|--|--|
-| [VGG19-Block1-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1) | (B, H, W, 3) | (B, H, W, 64) |   -   |
-| [VGG19-Block1-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1)  | (B, H, W, 64) | (B, H, W, 3) | 2.494 |
-| [VGG19-Block2-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/2, W/2, 128), (B * H * W * 16, 4)] |   -   |
-| [VGG19-Block2-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/decoder/1)  | [(B, H/2, W/2, 128), (B * H * W * 16, 4)] | (B, H, W, 3) | 3.859 |
-| [VGG19-Block3-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/4, W/4, 256), (B * H * W * 16, 4), (B * H * W * 8, 4)] |   -   |
-| [VGG19-Block3-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/decoder/1)  | [(B, H/4, W/4, 256), (B * H * W * 16, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 5.124 |
-| [VGG19-Block4-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/8, W/8, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4)] |   -   |
-| [VGG19-Block4-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/decoder/1)  | [(B, H/8, W/8, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 6.104 |
-| [VGG19-Block5-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4), (B * H * W * 2, 4)] |   -   |
-| [VGG19-Block5-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1)  | [(B, H/16, W/16, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4), (B * H * W * 2, 4)] | (B, H, W, 3) | 6.626 |
+| [VGG19-Block1-Conv2 Unpooling Encoder](https://tfhub.dev/emilutz/vgg19-block1-conv2-unpooling-encoder/1) | (B, H, W, 3) | (B, H, W, 64) |   -   |
+| [VGG19-Block1-Conv2 Unpooling Decoder](https://tfhub.dev/emilutz/vgg19-block1-conv2-unpooling-decoder/1)  | (B, H, W, 64) | (B, H, W, 3) | 2.494 |
+| [VGG19-Block2-Conv2 Unpooling Encoder](https://tfhub.dev/emilutz/vgg19-block2-conv2-unpooling-encoder/1)  | (B, H, W, 3) | [(B, H/2, W/2, 128), (B * H * W * 16, 4)] |   -   |
+| [VGG19-Block2-Conv2 Unpooling Decoder](https://tfhub.dev/emilutz/vgg19-block2-conv2-unpooling-decoder/1)  | [(B, H/2, W/2, 128), (B * H * W * 16, 4)] | (B, H, W, 3) | 3.859 |
+| [VGG19-Block3-Conv2 Unpooling Encoder](https://tfhub.dev/emilutz/vgg19-block3-conv2-unpooling-encoder/1)  | (B, H, W, 3) | [(B, H/4, W/4, 256), (B * H * W * 16, 4), (B * H * W * 8, 4)] |   -   |
+| [VGG19-Block3-Conv2 Unpooling Decoder](https://tfhub.dev/emilutz/vgg19-block3-conv2-unpooling-decoder/1)  | [(B, H/4, W/4, 256), (B * H * W * 16, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 5.124 |
+| [VGG19-Block4-Conv2 Unpooling Encoder](https://tfhub.dev/emilutz/vgg19-block4-conv2-unpooling-encoder/1)  | (B, H, W, 3) | [(B, H/8, W/8, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4)] |   -   |
+| [VGG19-Block4-Conv2 Unpooling Decoder](https://tfhub.dev/emilutz/vgg19-block4-conv2-unpooling-decoder/1)  | [(B, H/8, W/8, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 6.104 |
+| [VGG19-Block5-Conv2 Unpooling Encoder](https://tfhub.dev/emilutz/vgg19-block5-conv2-unpooling-encoder/1)  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4), (B * H * W * 2, 4)] |   -   |
+| [VGG19-Block5-Conv2 Unpooling Decoder](https://tfhub.dev/emilutz/vgg19-block5-conv2-unpooling-decoder/1)  | [(B, H/16, W/16, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4), (B * H * W * 2, 4)] | (B, H, W, 3) | 6.626 |
 
 The **L1 loss** was estimated from the loss on the test set consisting of 1234 samples from the COCO 2017 dataset. The values represent the mean absolute pixel difference across all channels (in the range [0, 255]).

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -47,4 +47,4 @@ Encoder inputs are expected to be batches of images of arbitrary height and widt
 | [VGG19-Block5-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] |   -   |
 | [VGG19-Block5-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1)  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.626 |
 
-The **L1 loss** was estimated from the loss on the test set consisting of 1234 samples from the COCO 2017 dataset.
+The **L1 loss** was estimated from the loss on the test set consisting of 1234 samples from the COCO 2017 dataset. The values represent the mean absolute pixel difference for all channels (in the range [0, 255]).

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -38,13 +38,13 @@ Encoder inputs are expected to be batches of images of arbitrary height and widt
 |--|--|--|--|
 | [VGG19-Block1-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1) | (B, H, W, 3) | (B, H, W, 64) |   -   |
 | [VGG19-Block1-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1)  | (B, H, W, 64) | (B, H, W, 3) | 2.494 |
-| [VGG19-Block2-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] |   -   |
-| [VGG19-Block2-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/decoder/1)  | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] | (B, H, W, 3) | 3.859 |
-| [VGG19-Block3-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] |   -   |
-| [VGG19-Block3-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/decoder/1)  | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 5.124 |
-| [VGG19-Block4-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] |   -   |
-| [VGG19-Block4-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/decoder/1)  | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 6.104 |
-| [VGG19-Block5-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] |   -   |
-| [VGG19-Block5-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1)  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.626 |
+| [VGG19-Block2-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/2, W/2, 128), (B * H * W * 16, 4)] |   -   |
+| [VGG19-Block2-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/decoder/1)  | [(B, H/2, W/2, 128), (B * H * W * 16, 4)] | (B, H, W, 3) | 3.859 |
+| [VGG19-Block3-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/4, W/4, 256), (B * H * W * 16, 4), (B * H * W * 8, 4)] |   -   |
+| [VGG19-Block3-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/decoder/1)  | [(B, H/4, W/4, 256), (B * H * W * 16, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 5.124 |
+| [VGG19-Block4-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/8, W/8, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4)] |   -   |
+| [VGG19-Block4-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/decoder/1)  | [(B, H/8, W/8, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 6.104 |
+| [VGG19-Block5-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4), (B * H * W * 2, 4)] |   -   |
+| [VGG19-Block5-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1)  | [(B, H/16, W/16, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4), (B * H * W * 2, 4)] | (B, H, W, 3) | 6.626 |
 
 The **L1 loss** was estimated from the loss on the test set consisting of 1234 samples from the COCO 2017 dataset. The values represent the mean absolute pixel difference across all channels (in the range [0, 255]).

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -1,0 +1,47 @@
+# Collection emilutz/vgg19-unpooling-encoder-decoder/1
+
+Collection of image encoders and decoders trained on the COCO 2017 dataset where:
+
+- encoders are VGG19 feature extarctors from various intermediary layers and store argmax information from max-poolings
+- decoders mirror the architecture of the encoders and use unpooling layers for upsampling
+
+<!-- dataset: COCO 2017 -->
+<!-- module-type: image-feature-vector -->
+
+
+## Overview
+
+The following are a set of 5 encoder-decoder pairs in the form of [TF2 SavedModels](https://www.tensorflow.org/hub/tf2_saved_model) and trained on [COCO 2017](https://cocodataset.org/) dataset. These models can be used for latent space manipulation for domains like style transfer or image stylization as exemplified here: https://arxiv.org/pdf/1802.06474.pdf.
+
+**Encoders** are nothing more than VGG19 subnetworks that kept their weights frozen during the training of the decoders. 
+
+**Decoders** were set to mirror the layout of their corresponding encoders and were trained from scratch to reconstruct the original images from their encoded feature vectors. Reconstruction of fine image structures was facilitated by using *unpooling layers* instead of conventional methods like deconvolutions or bilinear/nearest interpolation. In order to ensure the reconstructions are of high quality from other perspectives like actual pixel values, brightness or contrast, the decoders were trained to minimize a combination of 4 different losses:
+- L1 loss
+- L2 loss
+- MS-SSIM loss (computed as `1.0 - tf.image.ssim_multiscale(inputs, outputs, 255)`; more information about multi-scale structural similarity can be found here: https://www.cns.nyu.edu/pub/eero/wang03b.pdf)
+- Perceptual loss (computed as `tf.keras.losses.mean_squared_error(encoder(inputs), encoder(decoder(encoder(inputs))))` so every encoder also acts as the perceptual loss feature extractor for his decoder; more information about perceptual loss can be found here: https://arxiv.org/pdf/1603.08155.pdf)
+
+The weights used for the loss components were chosen in accordance to their magnitudes and are the following:
+- `lambda_l1 = 10.0`
+- `lambda_l2 = 1.0`
+- `lambda_ms_ssim = 1000.0`
+- `lambda_perceptual = 0.1`
+  
+The training process consisted of 30 epochs on 90% of the data, while 10% was used for validation.  Adam optimizer was used with the default parameters and a linear learning rate decay between 0.001 and 0.0002, and the only data augmentation used was a random horizontal flip on each batch. 
+
+## Models
+
+| Name | Input Shape | Output Shape | L1 loss* |
+|--|--|--|--|
+| VGG19-Block1-Conv2 Unpooling Encoder  | (B, H, W, 3) | (B, H, W, 64) |   -   |
+| VGG19-Block1-Conv2 Unpooling Decoder  | (B, H, W, 64) | (B, H, W, 3) | 2.391 |
+| VGG19-Block2-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] |   -   |
+| VGG19-Block2-Conv2 Unpooling Decoder  | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] | (B, H, W, 3) | 3.833 |
+| VGG19-Block3-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] |   -   |
+| VGG19-Block3-Conv2 Unpooling Decoder  | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 5.034 |
+| VGG19-Block4-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] |   -   |
+| VGG19-Block4-Conv2 Unpooling Decoder  | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 6.008 |
+| VGG19-Block5-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] |   -   |
+| VGG19-Block5-Conv2 Unpooling Decoder  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.615 |
+
+The **L1 loss** was estimated from the loss on the validation set which consisted of 11k+ images from the COCO 2017 dataset.

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -27,7 +27,7 @@ The weights used for the loss components were chosen in accordance to their magn
 - `lambda_ms_ssim = 1000.0`
 - `lambda_perceptual = 0.1`
   
-The training process consisted of 30 epochs on 90% of the data, while 10% was used for validation.  Adam optimizer was used with the default parameters and a linear learning rate decay between 0.001 and 0.0002, and the only data augmentation used was a random horizontal flip on each batch. 
+The training process consisted of 30 to 100 epochs on 90% of the data, while 10% was used for validation. Adam optimizer was used with the default parameters and a linear learning rate decay between 0.001 and 0.0002, and the only data augmentation used was a random horizontal flip on each batch.
 
 ## Models
 

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -5,9 +5,10 @@ Collection of image encoders and decoders trained on the COCO 2017 dataset where
 - encoders are VGG19 feature extarctors from various intermediary layers and store argmax information from max-poolings
 - decoders mirror the architecture of the encoders and use unpooling layers for upsampling
 
+<!-- license: MIT -->
 <!-- dataset: COCO 2017 -->
 <!-- module-type: image-feature-vector -->
-
+<!-- network-architecture: VGG-style -->
 
 ## Overview
 
@@ -35,15 +36,15 @@ Encoder inputs are expected to be batches of images of arbitrary height and widt
 
 | Name | Input Shape | Output Shape | L1 loss* |
 |--|--|--|--|
-| VGG19-Block1-Conv2 Unpooling Encoder  | (B, H, W, 3) | (B, H, W, 64) |   -   |
-| VGG19-Block1-Conv2 Unpooling Decoder  | (B, H, W, 64) | (B, H, W, 3) | 2.494 |
-| VGG19-Block2-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] |   -   |
-| VGG19-Block2-Conv2 Unpooling Decoder  | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] | (B, H, W, 3) | 3.859 |
-| VGG19-Block3-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] |   -   |
-| VGG19-Block3-Conv2 Unpooling Decoder  | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 5.124 |
-| VGG19-Block4-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] |   -   |
-| VGG19-Block4-Conv2 Unpooling Decoder  | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 6.104 |
-| VGG19-Block5-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] |   -   |
-| VGG19-Block5-Conv2 Unpooling Decoder  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.626 |
+| [VGG19-Block1-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1) | (B, H, W, 3) | (B, H, W, 64) |   -   |
+| [VGG19-Block1-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1)  | (B, H, W, 64) | (B, H, W, 3) | 2.494 |
+| [VGG19-Block2-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] |   -   |
+| [VGG19-Block2-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/decoder/1)  | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] | (B, H, W, 3) | 3.859 |
+| [VGG19-Block3-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] |   -   |
+| [VGG19-Block3-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/decoder/1)  | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 5.124 |
+| [VGG19-Block4-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] |   -   |
+| [VGG19-Block4-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/decoder/1)  | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 6.104 |
+| [VGG19-Block5-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] |   -   |
+| [VGG19-Block5-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1)  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.626 |
 
 The **L1 loss** was estimated from the loss on the test set consisting of 1234 samples from the COCO 2017 dataset.

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -47,4 +47,4 @@ Encoder inputs are expected to be batches of images of arbitrary height and widt
 | [VGG19-Block5-Conv2 Unpooling Encoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1)  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] |   -   |
 | [VGG19-Block5-Conv2 Unpooling Decoder](https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1)  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.626 |
 
-The **L1 loss** was estimated from the loss on the test set consisting of 1234 samples from the COCO 2017 dataset. The values represent the mean absolute pixel difference for all channels (in the range [0, 255]).
+The **L1 loss** was estimated from the loss on the test set consisting of 1234 samples from the COCO 2017 dataset. The values represent the mean absolute pixel difference across all channels (in the range [0, 255]).

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -1,9 +1,6 @@
 # Collection emilutz/vgg19-unpooling-encoder-decoder/1
 
-Collection of image encoders and decoders trained on the COCO 2017 dataset where:
-
-- encoders are VGG19 feature extarctors from various intermediary layers and store argmax information from max-poolings
-- decoders mirror the architecture of the encoders and use unpooling layers for upsampling
+Collection of image encoders and decoders trained on the COCO 2017 dataset where encoders are VGG19 feature extractors from various intermediary layers that store argmax information from max-pooling operations and decoders mirror the architecture of the encoders and use unpooling layers for upsampling.
 
 <!-- license: MIT -->
 <!-- dataset: COCO 2017 -->

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -31,7 +31,7 @@ The training process consisted of 30 to 100 epochs on 90% of the data, while 10%
 
 ## Models
 
-Encoder inputs are expected to be batches of images of arbitrary height and width but depending on the encoder-decoder pair used VGG19-Block**X**-Conv2 the sizes must be multiples of 2 ^ **X**. The outputs of the encoder are a list of the extracted image features + the argmax values for all maxpooling layers encountered until that point in the VGG19. For the decoders the input and output shapes are reversed.
+Encoder inputs are expected to be batches of images of arbitrary height and width but depending on the encoder-decoder pair used VGG19-Block**X**-Conv2 the sizes must be multiples of 2 ^ **X - 1**. The outputs of the encoder are a list of the extracted image features + the argmax values for all maxpooling layers encountered until that point in the VGG19. For the decoders the input and output shapes are reversed.
 
 | Name | Input Shape | Output Shape | L1 loss* |
 |--|--|--|--|

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -36,14 +36,14 @@ Encoder inputs are expected to be batches of images of arbitrary height and widt
 | Name | Input Shape | Output Shape | L1 loss* |
 |--|--|--|--|
 | VGG19-Block1-Conv2 Unpooling Encoder  | (B, H, W, 3) | (B, H, W, 64) |   -   |
-| VGG19-Block1-Conv2 Unpooling Decoder  | (B, H, W, 64) | (B, H, W, 3) | 2.391 |
+| VGG19-Block1-Conv2 Unpooling Decoder  | (B, H, W, 64) | (B, H, W, 3) | 2.494 |
 | VGG19-Block2-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] |   -   |
-| VGG19-Block2-Conv2 Unpooling Decoder  | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] | (B, H, W, 3) | 3.833 |
+| VGG19-Block2-Conv2 Unpooling Decoder  | [(B, H/2, W/2, 128), (B * H * W * 2, 4)] | (B, H, W, 3) | 3.859 |
 | VGG19-Block3-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] |   -   |
-| VGG19-Block3-Conv2 Unpooling Decoder  | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 5.034 |
+| VGG19-Block3-Conv2 Unpooling Decoder  | [(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)] | (B, H, W, 3) | 5.124 |
 | VGG19-Block4-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] |   -   |
-| VGG19-Block4-Conv2 Unpooling Decoder  | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 6.008 |
+| VGG19-Block4-Conv2 Unpooling Decoder  | [(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)] | (B, H, W, 3) | 6.104 |
 | VGG19-Block5-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] |   -   |
-| VGG19-Block5-Conv2 Unpooling Decoder  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.615 |
+| VGG19-Block5-Conv2 Unpooling Decoder  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.626 |
 
 The **L1 loss** was estimated from the loss on the validation set which consisted of 11k+ images from the COCO 2017 dataset.

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -31,6 +31,8 @@ The training process consisted of 30 epochs on 90% of the data, while 10% was us
 
 ## Models
 
+Encoder inputs are expected to be batches of images of arbitrary height and width but depending on the encoder-decoder pair used VGG19-Block**X**-Conv2 the sizes must be multiples of 2 ^ **X**. The outputs of the encoder are a list of the extracted image features + the argmax values for all maxpooling layers encountered until that point in the VGG19. For the decoders the input and output shapes are reversed.
+
 | Name | Input Shape | Output Shape | L1 loss* |
 |--|--|--|--|
 | VGG19-Block1-Conv2 Unpooling Encoder  | (B, H, W, 3) | (B, H, W, 64) |   -   |

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -32,7 +32,7 @@ The training process consisted of 30 to 100 epochs on 90% of the data, while 10%
 
 ## Models
 
-Encoder inputs are expected to be batches of images of arbitrary height and width but depending on the encoder-decoder pair used VGG19-Block**X**-Conv2 the sizes must be multiples of 2 ^ **X - 1**. The outputs of the encoder are a list of the extracted image features + the argmax values for all maxpooling layers encountered until that point in the VGG19. For the decoders the input and output shapes are reversed.
+Encoder inputs are expected to be batches of images of arbitrary height and width but depending on the encoder-decoder pair used VGG19-Block**X**-Conv2 the sizes must be multiples of 2 ^ **(X - 1)**. The outputs of the encoder are a list of the extracted image features + the argmax values for all maxpooling layers encountered until that point in the VGG19. For the decoders the input and output shapes are reversed.
 
 | Name | Input Shape | Output Shape | L1 loss* |
 |--|--|--|--|

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -28,7 +28,7 @@ The weights used for the loss components were chosen in accordance to their magn
 - `lambda_ms_ssim = 1000.0`
 - `lambda_perceptual = 0.1`
   
-The training process consisted of 30 to 100 epochs on 90% of the data, while 10% was used for validation. Adam optimizer was used with the default parameters and a linear learning rate decay between 0.001 and 0.0002, and the only data augmentation used was a random horizontal flip on each batch.
+The training process consisted of 30 to 100 epochs on 90% of the data, while 9% was used for validation and 1% left for testing. Adam optimizer was used with the default parameters and a linear learning rate decay between 0.001 and 0.0002, and the only data augmentation used was a random horizontal flip on each batch.
 
 ## Models
 

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -46,4 +46,4 @@ Encoder inputs are expected to be batches of images of arbitrary height and widt
 | VGG19-Block5-Conv2 Unpooling Encoder  | (B, H, W, 3) | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] |   -   |
 | VGG19-Block5-Conv2 Unpooling Decoder  | [(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)] | (B, H, W, 3) | 6.626 |
 
-The **L1 loss** was estimated from the loss on the validation set which consisted of 11k+ images from the COCO 2017 dataset.
+The **L1 loss** was estimated from the loss on the test set consisting of 1234 samples from the COCO 2017 dataset.

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -2,7 +2,6 @@
 
 Collection of image encoders and decoders trained on the COCO 2017 dataset where encoders are VGG19 feature extractors from various intermediary layers that store argmax information from max-pooling operations and decoders mirror the architecture of the encoders and use unpooling layers for upsampling.
 
-<!-- license: MIT -->
 <!-- dataset: COCO 2017 -->
 <!-- module-type: image-feature-vector -->
 <!-- network-architecture: VGG-style -->

--- a/assets/docs/emilutz/emilutz.md
+++ b/assets/docs/emilutz/emilutz.md
@@ -1,0 +1,11 @@
+# Publisher emilutz
+Emil Barbuta.
+
+[![Icon URL]](https://media-exp1.licdn.com/dms/image/C4D03AQETEtjkHoXB8Q/profile-displayphoto-shrink_200_200/0/1597656120860?e=1623283200&v=beta&t=m-2uZpLwqfIm5f4RVC16xDGCX0AGGEbFr6eAMhaXzVE)
+
+## Details
+Deep learning engineer at Oxford Nanoimaging. Machine learning image and audio art generation enthusiast.
+
+GitLab: [emilutz](https://gitlab.com/emilutz)
+GitHub: [emilutz](https://github.com/emilutz)
+LinkedIn: [EmilBarbuta](https://www.linkedin.com/in/emil-barbuta-883930153/)

--- a/assets/docs/emilutz/emilutz.md
+++ b/assets/docs/emilutz/emilutz.md
@@ -8,4 +8,4 @@ Deep Learning engineer at Oxford Nanoimaging. Machine Learning image and audio a
 
 GitLab: [emilutz](https://gitlab.com/emilutz)<br>
 GitHub: [emilutz](https://github.com/emilutz)<br>
-LinkedIn: [EmilBarbuta](https://www.linkedin.com/in/emil-barbuta-883930153/)<br>
+LinkedIn: [Emil Barbuta](https://www.linkedin.com/in/emil-barbuta-883930153/)<br>

--- a/assets/docs/emilutz/emilutz.md
+++ b/assets/docs/emilutz/emilutz.md
@@ -6,6 +6,6 @@ Emil Barbuta.
 ## Details
 Deep learning engineer at Oxford Nanoimaging. Machine learning image and audio art generation enthusiast.
 
-GitLab: [emilutz](https://gitlab.com/emilutz)
-GitHub: [emilutz](https://github.com/emilutz)
-LinkedIn: [EmilBarbuta](https://www.linkedin.com/in/emil-barbuta-883930153/)
+GitLab: [emilutz](https://gitlab.com/emilutz)<br>
+GitHub: [emilutz](https://github.com/emilutz)<br>
+LinkedIn: [EmilBarbuta](https://www.linkedin.com/in/emil-barbuta-883930153/)<br>

--- a/assets/docs/emilutz/emilutz.md
+++ b/assets/docs/emilutz/emilutz.md
@@ -1,10 +1,10 @@
 # Publisher emilutz
 Emil Barbuta.
 
-[![Icon URL]](https://media-exp1.licdn.com/dms/image/C4D03AQETEtjkHoXB8Q/profile-displayphoto-shrink_200_200/0/1597656120860?e=1623283200&v=beta&t=m-2uZpLwqfIm5f4RVC16xDGCX0AGGEbFr6eAMhaXzVE)
+[![Icon URL]](https://storage.googleapis.com/emilutz/radcliffe_camera.jpg)
 
 ## Details
-Deep learning engineer at Oxford Nanoimaging. Machine learning image and audio art generation enthusiast.
+Deep Learning engineer at Oxford Nanoimaging. Machine Learning image and audio art generation enthusiast.
 
 GitLab: [emilutz](https://gitlab.com/emilutz)<br>
 GitHub: [emilutz](https://github.com/emilutz)<br>

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
@@ -7,6 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
@@ -1,0 +1,82 @@
+# Module emilutz/vgg19-block1-conv2-unpooling-decoder/1
+
+Image decoder based on vgg19 that uses unpooling layers for upsampling.
+
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block1-conv2/decoder.tar.gz -->
+<!-- module-type: image-feature-vector -->
+<!-- fine-tunable: true -->
+<!-- dataset: COCO 2017 -->
+<!-- format: saved_model_2 -->
+<!-- license: MIT -->
+
+## Overview
+
+### Module description
+
+This model accepts as input a feature vector (extracted by passing an image through its pair encoder from block1_conv2 level of VGG19) and outputs the reconstructed image. It is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+
+### Model architecture
+
+This model contains only the component enclosed in the dashed line below.
+
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block1-conv2/decoder.png" height="384">
+
+### Input
+
+*   Inputs are expected to be vgg19-block1-conv2 encoded image features
+*   Shape: `(B, H, W, 64)`
+
+### Output
+
+*   Outputs are expected to be 3-channel RGB images with values in the range [0, 255]
+*   Shape: `(B, H, W, 3)`
+
+## Usage
+
+### Use SavedModel in Python
+
+```python
+import numpy as np
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# Load encoder and decoder
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1') # this model
+
+# Read image from disk and add batch size
+image_file = tf.io.read_file(image_path)
+image = tf.image.decode_image(image_file)
+image_batch = tf.expand_dims(image, axis=0)
+
+# Encode and decode the image
+image_features = encoder(image_batch)
+image_decoded = decoder(image_features)
+
+reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
+```
+
+## Training
+
+This decoder was trained on the COCO 2017 dataset for 100 epochs while keeping the weights of the encoder frozen. An Adam optimizer was used with default parameters and a linear learning rate decay betwwen 0.001 and 0.0002. In order to ensure the quality of the reconstructions is high from multiple points of view like pixel values proximity compared to the originals and maintenance of overall colour attributes like contrast and brightness, a combination of 4 losses was minimzed during training:
+- L1 loss
+- L2 loss
+- MS-SSIM loss (computed as `1.0 - tf.image.ssim_multiscale(inputs, outputs, 255)`; more information about multi-scale structural similarity can be found here: https://www.cns.nyu.edu/pub/eero/wang03b.pdf)
+- Perceptual loss (computed as `tf.keras.losses.mean_squared_error(encoder(inputs), encoder(decoder(encoder(inputs))))` so every encoder also acts as the perceptual loss feature extractor for his decoder; more information about perceptual loss can be found here: https://arxiv.org/pdf/1603.08155.pdf)
+
+The weights used for the loss components were chosen in accordance to their magnitudes and are the following:
+- `lambda_l1 = 10.0`
+- `lambda_l2 = 1.0`
+- `lambda_ms_ssim = 1000.0`
+- `lambda_perceptual = 0.1`
+
+### Training dataset
+
+COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)
+
+### Evaluation
+
+The mean absolute difference between the pixel values of the input images and their reconstructions `abs(input - decoder(encoder(input)))` for this pair as evaluated on the test set is *2.494*. 

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
@@ -58,7 +58,7 @@ reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
 
 ## Training
 
-This decoder was trained on the COCO 2017 dataset for 100 epochs while keeping the weights of the encoder frozen. An Adam optimizer was used with default parameters and a linear learning rate decay betwwen 0.001 and 0.0002. In order to ensure the quality of the reconstructions is high from multiple points of view like pixel values proximity compared to the originals and maintenance of overall colour attributes like contrast and brightness, a combination of 4 losses was minimzed during training:
+This decoder was trained on the COCO 2017 dataset for 100 epochs while keeping the weights of the encoder frozen. An Adam optimizer was used with default parameters and a linear learning rate decay between 0.001 and 0.0002. In order to ensure the quality of the reconstructions is high from multiple points of view like pixel values proximity compared to the originals and maintenance of overall colour attributes like contrast and brightness, a combination of 4 losses was minimzed during training:
 - L1 loss
 - L2 loss
 - MS-SSIM loss (computed as `1.0 - tf.image.ssim_multiscale(inputs, outputs, 255)`; more information about multi-scale structural similarity can be found here: https://www.cns.nyu.edu/pub/eero/wang03b.pdf)

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
@@ -42,8 +42,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1') # external model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1') # this model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block1-conv2-unpooling-encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block1-conv2-unpooling-decoder/1') # this model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
@@ -79,4 +79,4 @@ COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
 
 ### Evaluation
 
-The mean absolute difference between the pixel values of the input images and their reconstructions `abs(input - decoder(encoder(input)))` for this pair as evaluated on the test set is *2.494*. 
+The mean absolute difference between the pixel values of the input images and their reconstructions `abs(input - decoder(encoder(input)))` for this pair as evaluated on the test set is **2.494**. 

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
@@ -13,32 +13,53 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 
 ### Module description
 
-This model accepts as input an image and outputs the features extracted from block1_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. While training its corresponding decoder (which is a mirror of this model) the weights have been kept frozen. The pair was trained on the COCO 2017 dataset for 100 epochs using Adam optimizer with default parameters and a linear learning rate decay betwwen 0.001 and 0.0002.  
+This model accepts as input an image and outputs the features extracted from block1_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with high precision without introducing artifacts.
 
 ### Model architecture
 
+This model contains only the component enclosed in the dashed line below.
+
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19_block1_conv2/encoder.png" height="384">
+
 ### Input
+
+*   Inputs are expected to be 3-channel RGB colour images batches with values in the range [0, 255]
+*   Shape: `(B, H, W, 3)`
 
 ### Output
 
+*   Outputs are extracted image features 
+*   Shape: `(B, H, W, 64)`
 
 ## Usage
 
 ### Use SavedModel in Python
 
-``
-Code snippet demonstrating use (e.g. for a TF model using the tensorflow_hub library)
-
+```python
+import numpy as np
+import tensorflow as tf
 import tensorflow_hub as hub
 
-model = hub.KerasLayer(<model name>)
-inputs = ...
-output = model(inputs)
-``
+# Load encoder and decoder
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1') # external model
 
-## Performance
+# Read image from disk and add batch size
+image_file = tf.io.read_file(image_path)
+image = tf.image.decode_image(image_file)
+image_batch = tf.expand_dims(image, axis=0)
 
+# Encode and decode the image
+image_features = encoder(image_batch)
+image_decoded = decoder(image_features)
+
+reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
+```
 
 ## Training
 
+While training its corresponding decoder (which is a mirror of this encoder) the weights of this model have been kept frozen. The pair was trained on the COCO 2017 dataset for 100 epochs using Adam optimizer with default parameters and a linear learning rate decay betwwen 0.001 and 0.0002.
+
 ### Training dataset
+
+COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
@@ -1,0 +1,44 @@
+# Module emilutz/vgg19-block1-conv2-unpooling-encoder/1
+
+Image encoder based on vgg19 that stores argmax values for maxpool layers.
+
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19_block1_conv2/encoder.tar.gz -->
+<!-- module-type: image-feature-vector -->
+<!-- fine-tunable: true -->
+<!-- dataset: COCO 2017 -->
+<!-- format: saved_model_2 -->
+<!-- license: MIT -->
+
+## Overview
+
+### Module description
+
+This model accepts as input an image and outputs the features extracted from block1_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. While training its corresponding decoder (which is a mirror of this model) the weights have been kept frozen. The pair was trained on the COCO 2017 dataset for 100 epochs using Adam optimizer with default parameters and a linear learning rate decay betwwen 0.001 and 0.0002.  
+
+### Model architecture
+
+### Input
+
+### Output
+
+
+## Usage
+
+### Use SavedModel in Python
+
+``
+Code snippet demonstrating use (e.g. for a TF model using the tensorflow_hub library)
+
+import tensorflow_hub as hub
+
+model = hub.KerasLayer(<model name>)
+inputs = ...
+output = model(inputs)
+``
+
+## Performance
+
+
+## Training
+
+### Training dataset

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
@@ -58,7 +58,7 @@ reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
 
 ## Training
 
-While training its corresponding decoder (which is a mirror of this encoder) the weights of this model have been kept frozen. The pair was trained on the COCO 2017 dataset for 100 epochs using Adam optimizer with default parameters and a linear learning rate decay betwwen 0.001 and 0.0002.
+While training its corresponding decoder (which is a mirror of this encoder) the weights of this model have been kept frozen. The pair was trained on the COCO 2017 dataset for 100 epochs using Adam optimizer with default parameters and a linear learning rate decay between 0.001 and 0.0002.
 
 ### Training dataset
 

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
@@ -7,6 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
@@ -42,8 +42,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1') # this model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1') # external model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block1-conv2-unpooling-encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block1-conv2-unpooling-decoder/1') # external model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
@@ -2,7 +2,7 @@
 
 Image encoder based on vgg19 that stores argmax values for maxpool layers.
 
-<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19_block1_conv2/encoder.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block1-conv2/encoder.tar.gz -->
 <!-- module-type: image-feature-vector -->
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
@@ -13,17 +13,17 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 
 ### Module description
 
-This model accepts as input an image and outputs the features extracted from block1_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with high precision without introducing artifacts.
+This model accepts as input an image and outputs the features extracted from block1_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
 
 ### Model architecture
 
 This model contains only the component enclosed in the dashed line below.
 
-<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19_block1_conv2/encoder.png" height="384">
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block1-conv2/encoder.png" height="384">
 
 ### Input
 
-*   Inputs are expected to be 3-channel RGB colour images batches with values in the range [0, 255]
+*   Inputs are expected to be 3-channel RGB images with values in the range [0, 255]
 *   Shape: `(B, H, W, 3)`
 
 ### Output

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
@@ -65,3 +65,6 @@ While training its corresponding decoder (which is a mirror of this encoder) the
 ### Training dataset
 
 COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
@@ -7,6 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
@@ -1,8 +1,8 @@
-# Module emilutz/vgg19-block1-conv2-unpooling-decoder/1
+# Module emilutz/vgg19-block2-conv2-unpooling-decoder/1
 
 Image decoder based on vgg19 that uses unpooling layers for upsampling.
 
-<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block1-conv2/decoder.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block2-conv2/decoder.tar.gz -->
 <!-- module-type: image-feature-vector -->
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
@@ -13,18 +13,18 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 
 ### Module description
 
-This model accepts as input a feature vector (extracted by passing an image through its pair encoder from block1_conv2 level of VGG19) and outputs the reconstructed image. It is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+This model accepts as input a feature vector (extracted by passing an image through its pair encoder from block2_conv2 level of VGG19) and outputs the reconstructed image. It is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
 
 ### Model architecture
 
 This model contains only the component enclosed in the dashed line below.
 
-<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block1-conv2/decoder.png" height="384">
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block2-conv2/decoder.png" height="384">
 
 ### Input
 
-*   Inputs are expected to be vgg19-block1-conv2 encoded image features
-*   Shape: `(B, H, W, 64)`
+*   Inputs are expected to be vgg19-block2-conv2 encoded image features + maxpooling argmax indices
+*   Shape: `[(B, H/2, W/2, 128), (B * H * W * 2, 4)]`
 
 ### Output
 
@@ -41,8 +41,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1') # external model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1') # this model
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/decoder/1') # this model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)
@@ -51,8 +51,8 @@ image_float32 = tf.cast(image_uint8, tf.float32)
 image_batch = tf.expand_dims(image_float32, axis=0)
 
 # Encode and decode the image
-image_features = encoder(image_batch)
-image_decoded = decoder(image_features)
+[image_features, b1_indices] = encoder(image_batch)
+image_decoded = decoder([image_features, b1_indices])
 
 reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
 ```
@@ -80,4 +80,4 @@ COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
 
 ### Evaluation
 
-The mean absolute difference between the pixel values of the input images and their reconstructions `abs(input - decoder(encoder(input)))` for this pair as evaluated on the test set is **2.494**. 
+The mean absolute difference between the pixel values of the input images and their reconstructions `abs(input - decoder(encoder(input)))` for this pair as evaluated on the test set is **3.859**. 

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
@@ -42,8 +42,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/encoder/1') # external model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/decoder/1') # this model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block2-conv2-unpooling-encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block2-conv2-unpooling-decoder/1') # this model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
@@ -59,7 +59,7 @@ reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
 
 ## Training
 
-This decoder was trained on the COCO 2017 dataset for 100 epochs while keeping the weights of the encoder frozen. An Adam optimizer was used with default parameters and a linear learning rate decay between 0.001 and 0.0002. In order to ensure the quality of the reconstructions is high from multiple points of view like pixel values proximity compared to the originals and maintenance of overall colour attributes like contrast and brightness, a combination of 4 losses was minimzed during training:
+This decoder was trained on the COCO 2017 dataset for 30 epochs while keeping the weights of the encoder frozen. An Adam optimizer was used with default parameters and a linear learning rate decay between 0.001 and 0.0002. In order to ensure the quality of the reconstructions is high from multiple points of view like pixel values proximity compared to the originals and maintenance of overall colour attributes like contrast and brightness, a combination of 4 losses was minimzed during training:
 - L1 loss
 - L2 loss
 - MS-SSIM loss (computed as `1.0 - tf.image.ssim_multiscale(inputs, outputs, 255)`; more information about multi-scale structural similarity can be found here: https://www.cns.nyu.edu/pub/eero/wang03b.pdf)

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
@@ -25,7 +25,7 @@ This model contains only the component enclosed in the dashed line below.
 ### Input
 
 *   Inputs are expected to be vgg19-block2-conv2 encoded image features + maxpooling argmax indices
-*   Shape: `[(B, H/2, W/2, 128), (B * H * W * 2, 4)]`
+*   Shape: `[(B, H/2, W/2, 128), (B * H * W * 16, 4)]`
 
 ### Output
 

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
@@ -66,3 +66,6 @@ While training its corresponding decoder (which is a mirror of this encoder) the
 ### Training dataset
 
 COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
@@ -31,7 +31,7 @@ This model contains only the component enclosed in the dashed line below.
 ### Output
 
 *   Outputs are extracted image features + argmax indices of the pooling layer
-*   Shape: `[(B, H/2, W/2, 128), (B * H * W * 2, 4)]`
+*   Shape: `[(B, H/2, W/2, 128), (B * H * W * 16, 4)]`
 
 ## Usage
 

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
@@ -60,7 +60,7 @@ reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
 
 ## Training
 
-While training its corresponding decoder (which is a mirror of this encoder) the weights of this model have been kept frozen. The pair was trained on the COCO 2017 dataset for 100 epochs using Adam optimizer with default parameters and a linear learning rate decay between 0.001 and 0.0002.
+While training its corresponding decoder (which is a mirror of this encoder) the weights of this model have been kept frozen. The pair was trained on the COCO 2017 dataset for 30 epochs using Adam optimizer with default parameters and a linear learning rate decay between 0.001 and 0.0002.
 
 ### Training dataset
 

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
@@ -7,6 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
@@ -25,7 +25,7 @@ This model contains only the component enclosed in the dashed line below.
 
 *   Inputs are expected to be 3-channel RGB images with values in range [0, 255] and type float32
 *   Shape: `(B, H, W, 3)`
-*   `H` and `W` must be multiples of 2
+*   `H` and `W` must be multiples of 2 :warning:
 
 ### Output
 

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
@@ -1,8 +1,8 @@
-# Module emilutz/vgg19-block1-conv2-unpooling-encoder/1
+# Module emilutz/vgg19-block2-conv2-unpooling-encoder/1
 
 Image encoder based on vgg19 that stores argmax values for maxpool layers.
 
-<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block1-conv2/encoder.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block2-conv2/encoder.tar.gz -->
 <!-- module-type: image-feature-vector -->
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
@@ -13,23 +13,24 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 
 ### Module description
 
-This model accepts as input an image and outputs the features extracted from block1_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+This model accepts as input an image and outputs the features extracted from block2_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
 
 ### Model architecture
 
 This model contains only the component enclosed in the dashed line below.
 
-<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block1-conv2/encoder.png" height="384">
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block2-conv2/encoder.png" height="384">
 
 ### Input
 
 *   Inputs are expected to be 3-channel RGB images with values in range [0, 255] and type float32
 *   Shape: `(B, H, W, 3)`
+*   `H` and `W` must be multiples of 2
 
 ### Output
 
-*   Outputs are extracted image features 
-*   Shape: `(B, H, W, 64)`
+*   Outputs are extracted image features + argmax indices of the pooling layer
+*   Shape: `[(B, H/2, W/2, 128), (B * H * W * 2, 4)]`
 
 ## Usage
 
@@ -41,8 +42,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/encoder/1') # this model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block1-conv2/decoder/1') # external model
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/decoder/1') # external model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)
@@ -51,8 +52,8 @@ image_float32 = tf.cast(image_uint8, tf.float32)
 image_batch = tf.expand_dims(image_float32, axis=0)
 
 # Encode and decode the image
-image_features = encoder(image_batch)
-image_decoded = decoder(image_features)
+[image_features, b1_indices] = encoder(image_batch)
+image_decoded = decoder([image_features, b1_indices])
 
 reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
 ```

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
@@ -43,8 +43,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/encoder/1') # this model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block2-conv2/decoder/1') # external model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block2-conv2-unpooling-encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block2-conv2-unpooling-decoder/1') # external model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
@@ -7,6 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
@@ -25,7 +25,7 @@ This model contains only the component enclosed in the dashed line below.
 ### Input
 
 *   Inputs are expected to be vgg19-block3-conv2 encoded image features + maxpooling argmax indices
-*   Shape: `[(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)]`
+*   Shape: `[(B, H/4, W/4, 256), (B * H * W * 16, 4), (B * H * W * 8, 4)]`
 
 ### Output
 

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
@@ -1,0 +1,83 @@
+# Module emilutz/vgg19-block3-conv2-unpooling-decoder/1
+
+Image decoder based on vgg19 that uses unpooling layers for upsampling.
+
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block3-conv2/decoder.tar.gz -->
+<!-- module-type: image-feature-vector -->
+<!-- fine-tunable: true -->
+<!-- dataset: COCO 2017 -->
+<!-- format: saved_model_2 -->
+<!-- license: MIT -->
+
+## Overview
+
+### Module description
+
+This model accepts as input a feature vector (extracted by passing an image through its pair encoder from block3_conv2 level of VGG19) and outputs the reconstructed image. It is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+
+### Model architecture
+
+This model contains only the component enclosed in the dashed line below.
+
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block3-conv2/decoder.png" height="384">
+
+### Input
+
+*   Inputs are expected to be vgg19-block3-conv2 encoded image features + maxpooling argmax indices
+*   Shape: `[(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)]`
+
+### Output
+
+*   Outputs are expected to be 3-channel RGB images with values in range [0, 255] and type float32
+*   Shape: `(B, H, W, 3)`
+
+## Usage
+
+### Use SavedModel in Python
+
+```python
+import numpy as np
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# Load encoder and decoder
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/decoder/1') # this model
+
+# Read image from disk and add batch size
+image_file = tf.io.read_file(image_path)
+image_uint8 = tf.image.decode_image(image_file)
+image_float32 = tf.cast(image_uint8, tf.float32)
+image_batch = tf.expand_dims(image_float32, axis=0)
+
+# Encode and decode the image
+[image_features, b1_indices, b2_indices] = encoder(image_batch)
+image_decoded = decoder([image_features, b1_indices, b2_indices])
+
+reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
+```
+
+## Training
+
+This decoder was trained on the COCO 2017 dataset for 30 epochs while keeping the weights of the encoder frozen. An Adam optimizer was used with default parameters and a linear learning rate decay between 0.001 and 0.0002. In order to ensure the quality of the reconstructions is high from multiple points of view like pixel values proximity compared to the originals and maintenance of overall colour attributes like contrast and brightness, a combination of 4 losses was minimzed during training:
+- L1 loss
+- L2 loss
+- MS-SSIM loss (computed as `1.0 - tf.image.ssim_multiscale(inputs, outputs, 255)`; more information about multi-scale structural similarity can be found here: https://www.cns.nyu.edu/pub/eero/wang03b.pdf)
+- Perceptual loss (computed as `tf.keras.losses.mean_squared_error(encoder(inputs), encoder(decoder(encoder(inputs))))` so every encoder also acts as the perceptual loss feature extractor for his decoder; more information about perceptual loss can be found here: https://arxiv.org/pdf/1603.08155.pdf)
+
+The weights used for the loss components were chosen in accordance to their magnitudes and are the following:
+- `lambda_l1 = 10.0`
+- `lambda_l2 = 1.0`
+- `lambda_ms_ssim = 1000.0`
+- `lambda_perceptual = 0.1`
+
+### Training dataset
+
+COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)
+
+### Evaluation
+
+The mean absolute difference between the pixel values of the input images and their reconstructions `abs(input - decoder(encoder(input)))` for this pair as evaluated on the test set is **5.124**. 

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
@@ -42,8 +42,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/encoder/1') # external model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/decoder/1') # this model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block3-conv2-unpooling-encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block3-conv2-unpooling-decoder/1') # this model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
@@ -66,3 +66,6 @@ While training its corresponding decoder (which is a mirror of this encoder) the
 ### Training dataset
 
 COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
@@ -7,6 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
@@ -43,8 +43,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/encoder/1') # this model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/decoder/1') # external model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block3-conv2-unpooling-encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block3-conv2-unpooling-decoder/1') # external model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
@@ -1,0 +1,67 @@
+# Module emilutz/vgg19-block3-conv2-unpooling-encoder/1
+
+Image encoder based on vgg19 that stores argmax values for maxpool layers.
+
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block3-conv2/encoder.tar.gz -->
+<!-- module-type: image-feature-vector -->
+<!-- fine-tunable: true -->
+<!-- dataset: COCO 2017 -->
+<!-- format: saved_model_2 -->
+<!-- license: MIT -->
+
+## Overview
+
+### Module description
+
+This model accepts as input an image and outputs the features extracted from block3_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+
+### Model architecture
+
+This model contains only the component enclosed in the dashed line below.
+
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block3-conv2/encoder.png" height="384">
+
+### Input
+
+*   Inputs are expected to be 3-channel RGB images with values in range [0, 255] and type float32
+*   Shape: `(B, H, W, 3)`
+*   `H` and `W` must be multiples of 4 :warning:
+
+### Output
+
+*   Outputs are extracted image features + argmax indices of the pooling layer
+*   Shape: `[(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)]`
+
+## Usage
+
+### Use SavedModel in Python
+
+```python
+import numpy as np
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# Load encoder and decoder
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block3-conv2/decoder/1') # external model
+
+# Read image from disk and add batch size
+image_file = tf.io.read_file(image_path)
+image_uint8 = tf.image.decode_image(image_file)
+image_float32 = tf.cast(image_uint8, tf.float32)
+image_batch = tf.expand_dims(image_float32, axis=0)
+
+# Encode and decode the image
+[image_features, b1_indices, b2_indices] = encoder(image_batch)
+image_decoded = decoder([image_features, b1_indices, b2_indices])
+
+reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
+```
+
+## Training
+
+While training its corresponding decoder (which is a mirror of this encoder) the weights of this model have been kept frozen. The pair was trained on the COCO 2017 dataset for 30 epochs using Adam optimizer with default parameters and a linear learning rate decay between 0.001 and 0.0002.
+
+### Training dataset
+
+COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
@@ -31,7 +31,7 @@ This model contains only the component enclosed in the dashed line below.
 ### Output
 
 *   Outputs are extracted image features + argmax indices of the pooling layer
-*   Shape: `[(B, H/4, W/4, 256), (B * H * W * 2, 4), (B * H * W * 4, 4)]`
+*   Shape: `[(B, H/4, W/4, 256), (B * H * W * 16, 4), (B * H * W * 8, 4)]`
 
 ## Usage
 

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
@@ -7,6 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
@@ -42,8 +42,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/encoder/1') # external model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/decoder/1') # this model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block4-conv2-unpooling-encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block4-conv2-unpooling-decoder/1') # this model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
@@ -1,0 +1,83 @@
+# Module emilutz/vgg19-block4-conv2-unpooling-decoder/1
+
+Image decoder based on vgg19 that uses unpooling layers for upsampling.
+
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block4-conv2/decoder.tar.gz -->
+<!-- module-type: image-feature-vector -->
+<!-- fine-tunable: true -->
+<!-- dataset: COCO 2017 -->
+<!-- format: saved_model_2 -->
+<!-- license: MIT -->
+
+## Overview
+
+### Module description
+
+This model accepts as input a feature vector (extracted by passing an image through its pair encoder from block4_conv2 level of VGG19) and outputs the reconstructed image. It is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+
+### Model architecture
+
+This model contains only the component enclosed in the dashed line below.
+
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block4-conv2/decoder.png" height="384">
+
+### Input
+
+*   Inputs are expected to be vgg19-block4-conv2 encoded image features + maxpooling argmax indices
+*   Shape: `[(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)]`
+
+### Output
+
+*   Outputs are expected to be 3-channel RGB images with values in range [0, 255] and type float32
+*   Shape: `(B, H, W, 3)`
+
+## Usage
+
+### Use SavedModel in Python
+
+```python
+import numpy as np
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# Load encoder and decoder
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/decoder/1') # this model
+
+# Read image from disk and add batch size
+image_file = tf.io.read_file(image_path)
+image_uint8 = tf.image.decode_image(image_file)
+image_float32 = tf.cast(image_uint8, tf.float32)
+image_batch = tf.expand_dims(image_float32, axis=0)
+
+# Encode and decode the image
+[image_features, b1_indices, b2_indices, b3_indices] = encoder(image_batch)
+image_decoded = decoder([image_features, b1_indices, b2_indices, b3_indices])
+
+reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
+```
+
+## Training
+
+This decoder was trained on the COCO 2017 dataset for 30 epochs while keeping the weights of the encoder frozen. An Adam optimizer was used with default parameters and a linear learning rate decay between 0.001 and 0.0002. In order to ensure the quality of the reconstructions is high from multiple points of view like pixel values proximity compared to the originals and maintenance of overall colour attributes like contrast and brightness, a combination of 4 losses was minimzed during training:
+- L1 loss
+- L2 loss
+- MS-SSIM loss (computed as `1.0 - tf.image.ssim_multiscale(inputs, outputs, 255)`; more information about multi-scale structural similarity can be found here: https://www.cns.nyu.edu/pub/eero/wang03b.pdf)
+- Perceptual loss (computed as `tf.keras.losses.mean_squared_error(encoder(inputs), encoder(decoder(encoder(inputs))))` so every encoder also acts as the perceptual loss feature extractor for his decoder; more information about perceptual loss can be found here: https://arxiv.org/pdf/1603.08155.pdf)
+
+The weights used for the loss components were chosen in accordance to their magnitudes and are the following:
+- `lambda_l1 = 10.0`
+- `lambda_l2 = 1.0`
+- `lambda_ms_ssim = 1000.0`
+- `lambda_perceptual = 0.1`
+
+### Training dataset
+
+COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)
+
+### Evaluation
+
+The mean absolute difference between the pixel values of the input images and their reconstructions `abs(input - decoder(encoder(input)))` for this pair as evaluated on the test set is **6.104**. 

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
@@ -25,7 +25,7 @@ This model contains only the component enclosed in the dashed line below.
 ### Input
 
 *   Inputs are expected to be vgg19-block4-conv2 encoded image features + maxpooling argmax indices
-*   Shape: `[(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)]`
+*   Shape: `[(B, H/8, W/8, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4)]`
 
 ### Output
 

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
@@ -19,7 +19,7 @@ This model accepts as input a feature vector (extracted by passing an image thro
 
 This model contains only the component enclosed in the dashed line below.
 
-<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block4-conv2/decoder.png" height="384">
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block4-conv2/decoder.png" height="256">
 
 ### Input
 

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
@@ -66,3 +66,6 @@ While training its corresponding decoder (which is a mirror of this encoder) the
 ### Training dataset
 
 COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
@@ -1,0 +1,67 @@
+# Module emilutz/vgg19-block4-conv2-unpooling-encoder/1
+
+Image encoder based on vgg19 that stores argmax values for maxpool layers.
+
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block4-conv2/encoder.tar.gz -->
+<!-- module-type: image-feature-vector -->
+<!-- fine-tunable: true -->
+<!-- dataset: COCO 2017 -->
+<!-- format: saved_model_2 -->
+<!-- license: MIT -->
+
+## Overview
+
+### Module description
+
+This model accepts as input an image and outputs the features extracted from block4_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+
+### Model architecture
+
+This model contains only the component enclosed in the dashed line below.
+
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block4-conv2/encoder.png" height="384">
+
+### Input
+
+*   Inputs are expected to be 3-channel RGB images with values in range [0, 255] and type float32
+*   Shape: `(B, H, W, 3)`
+*   `H` and `W` must be multiples of 8 :warning:
+
+### Output
+
+*   Outputs are extracted image features + argmax indices of the pooling layer
+*   Shape: `[(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)]`
+
+## Usage
+
+### Use SavedModel in Python
+
+```python
+import numpy as np
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# Load encoder and decoder
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/decoder/1') # external model
+
+# Read image from disk and add batch size
+image_file = tf.io.read_file(image_path)
+image_uint8 = tf.image.decode_image(image_file)
+image_float32 = tf.cast(image_uint8, tf.float32)
+image_batch = tf.expand_dims(image_float32, axis=0)
+
+# Encode and decode the image
+[image_features, b1_indices, b2_indices, b3_indices] = encoder(image_batch)
+image_decoded = decoder([image_features, b1_indices, b2_indices, b3_indices])
+
+reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
+```
+
+## Training
+
+While training its corresponding decoder (which is a mirror of this encoder) the weights of this model have been kept frozen. The pair was trained on the COCO 2017 dataset for 30 epochs using Adam optimizer with default parameters and a linear learning rate decay between 0.001 and 0.0002.
+
+### Training dataset
+
+COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
@@ -31,7 +31,7 @@ This model contains only the component enclosed in the dashed line below.
 ### Output
 
 *   Outputs are extracted image features + argmax indices of the pooling layer
-*   Shape: `[(B, H/8, W/8, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4)]`
+*   Shape: `[(B, H/8, W/8, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4)]`
 
 ## Usage
 

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
@@ -7,6 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
@@ -19,7 +19,7 @@ This model accepts as input an image and outputs the features extracted from blo
 
 This model contains only the component enclosed in the dashed line below.
 
-<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block4-conv2/encoder.png" height="384">
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block4-conv2/encoder.png" height="256">
 
 ### Input
 

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
@@ -43,8 +43,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/encoder/1') # this model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block4-conv2/decoder/1') # external model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block4-conv2-unpooling-encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block4-conv2-unpooling-decoder/1') # external model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
@@ -7,6 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
@@ -42,8 +42,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1') # external model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1') # this model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block5-conv2-unpooling-encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block5-conv2-unpooling-decoder/1') # this model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
@@ -1,0 +1,83 @@
+# Module emilutz/vgg19-block5-conv2-unpooling-decoder/1
+
+Image decoder based on vgg19 that uses unpooling layers for upsampling.
+
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block5-conv2/decoder.tar.gz -->
+<!-- module-type: image-feature-vector -->
+<!-- fine-tunable: true -->
+<!-- dataset: COCO 2017 -->
+<!-- format: saved_model_2 -->
+<!-- license: MIT -->
+
+## Overview
+
+### Module description
+
+This model accepts as input a feature vector (extracted by passing an image through its pair encoder from block5_conv2 level of VGG19) and outputs the reconstructed image. It is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+
+### Model architecture
+
+This model contains only the component enclosed in the dashed line below.
+
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block5-conv2/decoder.png" height="384">
+
+### Input
+
+*   Inputs are expected to be vgg19-block5-conv2 encoded image features + maxpooling argmax indices
+*   Shape: `[(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)]`
+
+### Output
+
+*   Outputs are expected to be 3-channel RGB images with values in range [0, 255] and type float32
+*   Shape: `(B, H, W, 3)`
+
+## Usage
+
+### Use SavedModel in Python
+
+```python
+import numpy as np
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# Load encoder and decoder
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1') # external model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1') # this model
+
+# Read image from disk and add batch size
+image_file = tf.io.read_file(image_path)
+image_uint8 = tf.image.decode_image(image_file)
+image_float32 = tf.cast(image_uint8, tf.float32)
+image_batch = tf.expand_dims(image_float32, axis=0)
+
+# Encode and decode the image
+[image_features, b1_indices, b2_indices, b3_indices, b4_indices] = encoder(image_batch)
+image_decoded = decoder([image_features, b1_indices, b2_indices, b3_indices, b4_indices])
+
+reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
+```
+
+## Training
+
+This decoder was trained on the COCO 2017 dataset for 30 epochs while keeping the weights of the encoder frozen. An Adam optimizer was used with default parameters and a linear learning rate decay between 0.001 and 0.0002. In order to ensure the quality of the reconstructions is high from multiple points of view like pixel values proximity compared to the originals and maintenance of overall colour attributes like contrast and brightness, a combination of 4 losses was minimzed during training:
+- L1 loss
+- L2 loss
+- MS-SSIM loss (computed as `1.0 - tf.image.ssim_multiscale(inputs, outputs, 255)`; more information about multi-scale structural similarity can be found here: https://www.cns.nyu.edu/pub/eero/wang03b.pdf)
+- Perceptual loss (computed as `tf.keras.losses.mean_squared_error(encoder(inputs), encoder(decoder(encoder(inputs))))` so every encoder also acts as the perceptual loss feature extractor for his decoder; more information about perceptual loss can be found here: https://arxiv.org/pdf/1603.08155.pdf)
+
+The weights used for the loss components were chosen in accordance to their magnitudes and are the following:
+- `lambda_l1 = 10.0`
+- `lambda_l2 = 1.0`
+- `lambda_ms_ssim = 1000.0`
+- `lambda_perceptual = 0.1`
+
+### Training dataset
+
+COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)
+
+### Evaluation
+
+The mean absolute difference between the pixel values of the input images and their reconstructions `abs(input - decoder(encoder(input)))` for this pair as evaluated on the test set is **6.626**. 

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
@@ -25,7 +25,7 @@ This model contains only the component enclosed in the dashed line below.
 ### Input
 
 *   Inputs are expected to be vgg19-block5-conv2 encoded image features + maxpooling argmax indices
-*   Shape: `[(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)]`
+*   Shape: `[(B, H/16, W/16, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4), (B * H * W * 2, 4)]`
 
 ### Output
 

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
@@ -19,7 +19,7 @@ This model accepts as input a feature vector (extracted by passing an image thro
 
 This model contains only the component enclosed in the dashed line below.
 
-<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block5-conv2/decoder.png" height="384">
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block5-conv2/decoder.png" height="192">
 
 ### Input
 

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
@@ -66,3 +66,6 @@ While training its corresponding decoder (which is a mirror of this encoder) the
 ### Training dataset
 
 COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.
+- 90% used for training (111063 images)
+- 9% used for validation (11106 images)
+- 1% left for testing (1234 images)

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
@@ -7,6 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: COCO 2017 -->
 <!-- format: saved_model_2 -->
+<!-- network-architecture: VGG-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
@@ -43,8 +43,8 @@ import tensorflow as tf
 import tensorflow_hub as hub
 
 # Load encoder and decoder
-encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1') # this model
-decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1') # external model
+encoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block5-conv2-unpooling-encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/emilutz/vgg19-block5-conv2-unpooling-decoder/1') # external model
 
 # Read image from disk and add batch size
 image_file = tf.io.read_file(image_path)

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
@@ -19,7 +19,7 @@ This model accepts as input an image and outputs the features extracted from blo
 
 This model contains only the component enclosed in the dashed line below.
 
-<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block5-conv2/encoder.png" height="384">
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block5-conv2/encoder.png" height="192">
 
 ### Input
 

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
@@ -31,7 +31,7 @@ This model contains only the component enclosed in the dashed line below.
 ### Output
 
 *   Outputs are extracted image features + argmax indices of the pooling layer
-*   Shape: `[(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)]`
+*   Shape: `[(B, H/16, W/16, 512), (B * H * W * 16, 4), (B * H * W * 8, 4), (B * H * W * 4, 4), (B * H * W * 2, 4)]`
 
 ## Usage
 

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
@@ -1,0 +1,67 @@
+# Module emilutz/vgg19-block5-conv2-unpooling-encoder/1
+
+Image encoder based on vgg19 that stores argmax values for maxpool layers.
+
+<!-- asset-path: https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block5-conv2/encoder.tar.gz -->
+<!-- module-type: image-feature-vector -->
+<!-- fine-tunable: true -->
+<!-- dataset: COCO 2017 -->
+<!-- format: saved_model_2 -->
+<!-- license: MIT -->
+
+## Overview
+
+### Module description
+
+This model accepts as input an image and outputs the features extracted from block5_conv2 level of VGG19. It served as a feature extractor for training an encoder-decoder structure based on VGG19 and is part of a larger collection of such pairs designed to offer the ability to manipulate images by changing the latent space. One example of such use case can be found in style transfer applications like https://arxiv.org/abs/1802.06474. The addition of unpooling layers (as oposed to using regular upsampling methods) ensures fine image details are reconstructed with higher precision and without introducing artifacts.
+
+### Model architecture
+
+This model contains only the component enclosed in the dashed line below.
+
+<img src="https://storage.googleapis.com/vgg19-with-unpooling/vgg19-block5-conv2/encoder.png" height="384">
+
+### Input
+
+*   Inputs are expected to be 3-channel RGB images with values in range [0, 255] and type float32
+*   Shape: `(B, H, W, 3)`
+*   `H` and `W` must be multiples of 16 :warning:
+
+### Output
+
+*   Outputs are extracted image features + argmax indices of the pooling layer
+*   Shape: `[(B, H/16, W/16, 512), (B * H * W * 2, 4), (B * H * W * 4, 4), (B * H * W * 8, 4), (B * H * W * 16, 4)]`
+
+## Usage
+
+### Use SavedModel in Python
+
+```python
+import numpy as np
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# Load encoder and decoder
+encoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/encoder/1') # this model
+decoder = hub.KerasLayer('https://tfhub.dev/vgg19-with-unpooling/vgg19-block5-conv2/decoder/1') # external model
+
+# Read image from disk and add batch size
+image_file = tf.io.read_file(image_path)
+image_uint8 = tf.image.decode_image(image_file)
+image_float32 = tf.cast(image_uint8, tf.float32)
+image_batch = tf.expand_dims(image_float32, axis=0)
+
+# Encode and decode the image
+[image_features, b1_indices, b2_indices, b3_indices, b4_indices] = encoder(image_batch)
+image_decoded = decoder([image_features, b1_indices, b2_indices, b3_indices, b4_indices])
+
+reconstruction_loss = np.abs((image_decoded - image_batch).numpy()).mean()
+```
+
+## Training
+
+While training its corresponding decoder (which is a mirror of this encoder) the weights of this model have been kept frozen. The pair was trained on the COCO 2017 dataset for 30 epochs using Adam optimizer with default parameters and a linear learning rate decay between 0.001 and 0.0002.
+
+### Training dataset
+
+COCO 2017 Unlabelled images (123K) https://cocodataset.org/#download.


### PR DESCRIPTION
I uploaded a set of encoder-decoders based on VGG19 with some modifications for better image reconstruction. One thing I didn't understand is how do models get their tfhub url when hosted? In the sample code I used a tfhub url for downloading the models which does not exist at the moment.
