### PR TITLE
Use architecture IDs from network_architecture.yaml

### DIFF
--- a/assets/docs/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1.md
+++ b/assets/docs/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/1.md
@@ -6,7 +6,7 @@ Image Classification model for mushroom species identification.
 <!-- format: saved_model -->
 <!-- asset-path: http://ptak.felk.cvut.cz/personal/picekluk/DanishSvampeAtlas/Inception_v4_saved_model_1.tar.gz -->
 <!-- module-type: image-classification -->
-<!-- network-architecture: Inception V4 -->
+<!-- network-architecture: inception-v4 -->
 <!-- license: MIT -->
 <!-- interactive-model-name: vision -->
 

--- a/assets/docs/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/2.md
+++ b/assets/docs/bohemian-visual-recognition-alliance/models/mushroom-identification_v1/2.md
@@ -6,7 +6,7 @@ Lightweights Image Classification model for mushroom species identification.
 <!-- format: saved_model -->
 <!-- asset-path: http://ptak.felk.cvut.cz/personal/picekluk/DanishSvampeAtlas/MobileNet_v3_360_saved_model_2.tar.gz -->
 <!-- module-type: image-classification -->
-<!-- network-architecture: MobileNet V3 -->
+<!-- network-architecture: mobilenet-v3 -->
 <!-- license: MIT -->
 <!-- interactive-model-name: vision -->
 

--- a/assets/docs/captain-pool/esrgan-tf2/1.md
+++ b/assets/docs/captain-pool/esrgan-tf2/1.md
@@ -6,7 +6,7 @@ Works best on Bicubically downsampled images.\
 
 <!-- asset-path: legacy -->
 <!-- module-type: image-super-resolution -->
-<!-- network-architecture: GAN -->
+<!-- network-architecture: gan -->
 <!-- dataset: div2k -->
 <!-- language: en -->
 <!-- fine-tunable: true -->

--- a/assets/docs/digitalepidemiologylab/models/covid-twitter-bert/1.md
+++ b/assets/docs/digitalepidemiologylab/models/covid-twitter-bert/1.md
@@ -3,7 +3,7 @@ BERT-large-uncased model, pretrained on a corpus of messages from Twitter about 
 
 <!-- asset-path: https://crowdbreaks-public.s3.eu-central-1.amazonaws.com/models/covid-twitter-bert/v1/tfhub/covid-twitter-bert-v1.tar.gz -->
 <!-- module-type: text-embedding -->
-<!-- network-architecture: Transformer -->
+<!-- network-architecture: transformer -->
 <!-- dataset: twitter -->
 <!-- language: en -->
 <!-- fine-tunable: true -->

--- a/assets/docs/digitalepidemiologylab/models/covid-twitter-bert/2.md
+++ b/assets/docs/digitalepidemiologylab/models/covid-twitter-bert/2.md
@@ -3,7 +3,7 @@ BERT-large-uncased model, pretrained on a corpus of messages from Twitter about 
 
 <!-- asset-path: https://crowdbreaks-public.s3.eu-central-1.amazonaws.com/models/covid-twitter-bert/v2/tfhub/covid-twitter-bert-v2.tar.gz -->
 <!-- module-type: text-embedding -->
-<!-- network-architecture: Transformer -->
+<!-- network-architecture: transformer -->
 <!-- dataset: twitter -->
 <!-- language: en -->
 <!-- fine-tunable: true -->

--- a/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
+++ b/assets/docs/emilutz/collections/vgg19-unpooling-encoder-decoder/1.md
@@ -4,7 +4,7 @@ Collection of image encoders and decoders trained on the COCO 2017 dataset where
 
 <!-- dataset: coco-2017 -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 
 ## Overview
 

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-decoder/1.md
@@ -7,7 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block1-conv2-unpooling-encoder/1.md
@@ -7,7 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-decoder/1.md
@@ -7,7 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block2-conv2-unpooling-encoder/1.md
@@ -7,7 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-decoder/1.md
@@ -7,7 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block3-conv2-unpooling-encoder/1.md
@@ -7,7 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-decoder/1.md
@@ -7,7 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block4-conv2-unpooling-encoder/1.md
@@ -7,7 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-decoder/1.md
@@ -7,7 +7,7 @@ Image decoder based on vgg19 that uses unpooling layers for upsampling.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
+++ b/assets/docs/emilutz/models/vgg19-block5-conv2-unpooling-encoder/1.md
@@ -7,7 +7,7 @@ Image encoder based on vgg19 that stores argmax values for maxpool layers.
 <!-- fine-tunable: true -->
 <!-- dataset: coco-2017 -->
 <!-- format: saved_model_2 -->
-<!-- network-architecture: VGG-style -->
+<!-- network-architecture: vgg-style -->
 <!-- license: MIT -->
 
 ## Overview

--- a/assets/docs/intel/midas/v2/1/1.md
+++ b/assets/docs/intel/midas/v2/1/1.md
@@ -3,7 +3,7 @@ Convolutional neural network for monocular depth estimation from a single RGB im
 
 <!-- asset-path: legacy -->
 <!-- module-type: image-depth-estimation -->
-<!-- network-architecture: MiDaS -->
+<!-- network-architecture: midas -->
 <!-- dataset: diml-indoor -->
 <!-- dataset: megadepth -->
 <!-- dataset: redweb -->

--- a/assets/docs/intel/midas/v2/1/2.md
+++ b/assets/docs/intel/midas/v2/1/2.md
@@ -3,7 +3,7 @@ Convolutional neural network for monocular depth estimation from a single RGB im
 
 <!-- asset-path: legacy -->
 <!-- module-type: image-depth-estimation -->
-<!-- network-architecture: MiDaS -->
+<!-- network-architecture: midas -->
 <!-- dataset: diml-indoor -->
 <!-- dataset: megadepth -->
 <!-- dataset: redweb -->

--- a/assets/docs/intel/midas/v2_1_small/1/1.md
+++ b/assets/docs/intel/midas/v2_1_small/1/1.md
@@ -3,7 +3,7 @@ Mobile convolutional neural network for monocular depth estimation from a single
 
 <!-- asset-path: legacy -->
 <!-- module-type: image-depth-estimation -->
-<!-- network-architecture: MiDaS -->
+<!-- network-architecture: midas -->
 <!-- dataset: diml-indoor -->
 <!-- dataset: megadepth -->
 <!-- dataset: redweb -->

--- a/assets/docs/metmuseum/models/vision/classifier/imet_attributes_V1/1.md
+++ b/assets/docs/metmuseum/models/vision/classifier/imet_attributes_V1/1.md
@@ -5,7 +5,7 @@ Image attribute classifier trained on the iMet Collection 2019 dataset.
 <!-- dataset: imet-collection-2019 -->
 <!-- asset-path: legacy -->
 <!-- module-type: image-classification-logits-->
-<!-- network-architecture: Inception V4 -->
+<!-- network-architecture: inception-v4 -->
 <!-- fine-tunable: false -->
 <!-- format: hub -->
 <!-- interactive-model-name: imet_attribute_classifier -->

--- a/assets/docs/nascarr/models/nq/1.md
+++ b/assets/docs/nascarr/models/nq/1.md
@@ -4,7 +4,7 @@ Question Answering model trained on Natural Questions Dataset [1, 2].
 
 <!-- asset-path: https://github.com/nascarr/natural-questions/raw/master/models/v1/model.tar.gz -->
 <!-- module-type: text-question-answering -->
-<!-- network-architecture: Transformer -->
+<!-- network-architecture: transformer -->
 <!-- dataset: natural-questions -->
 <!-- language: en -->
 <!-- fine-tunable: true -->

--- a/assets/docs/nvidia/models/unet/industrial/class_1/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_1/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_1/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_10/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_10/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_10/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_2/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_2/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_2/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_3/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_3/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_3/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_4/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_4/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_4/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_5/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_5/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_5/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_6/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_6/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_6/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_7/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_7/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_7/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_8/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_8/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_8/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/nvidia/models/unet/industrial/class_9/1.md
+++ b/assets/docs/nvidia/models/unet/industrial/class_9/1.md
@@ -3,7 +3,7 @@ Convolutional auto-encoder for 2D image segmentation.
 
 <!-- asset-path: https://developer.download.nvidia.com/compute/redist/Binary_Files/unet_tfhub_modules/class_9/1.tar.gz -->
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: Unet -->
+<!-- network-architecture: unet -->
 <!-- dataset: dagm2007 -->
 <!-- fine-tunable: false  -->
 <!-- format: hub -->

--- a/assets/docs/prvi/tf2-nq/1.md
+++ b/assets/docs/prvi/tf2-nq/1.md
@@ -3,7 +3,7 @@ Question Answering model for Kaggle TensorFlow 2.0 Question Answering challenge 
 
 <!-- asset-path: https://hpz400.cs.elte.hu/model/model.tar.gz -->
 <!-- module-type: text-question-answering -->
-<!-- network-architecture: Transformer -->
+<!-- network-architecture: transformer -->
 <!-- dataset: natural-questions -->
 <!-- language: en -->
 <!-- fine-tunable: true -->

--- a/assets/docs/sayakpaul/arbitrary-image-stylization-inceptionv3-dynamic-shapes/1.md
+++ b/assets/docs/sayakpaul/arbitrary-image-stylization-inceptionv3-dynamic-shapes/1.md
@@ -3,6 +3,6 @@ Fast arbitrary image style transfer based on an InceptionV3 backbone.
 
 <!-- dataset: multiple -->
 <!-- module-type: image-style-transfer -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/arbitrary-image-stylization-inceptionv3/1.md
+++ b/assets/docs/sayakpaul/arbitrary-image-stylization-inceptionv3/1.md
@@ -3,7 +3,7 @@ Fast arbitrary image style transfer based on an InceptionV3 backbone.
 
 <!-- dataset: multiple -->
 <!-- module-type: image-style-transfer -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/boundless_quarter/1.md
+++ b/assets/docs/sayakpaul/boundless_quarter/1.md
@@ -3,6 +3,6 @@ TFLite quantized GAN-model for image extrapolation.
 
 <!-- dataset: multiple -->
 <!-- module-type: image-style-transfer -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/cartoongan/1.md
+++ b/assets/docs/sayakpaul/cartoongan/1.md
@@ -3,6 +3,6 @@ CartoonGAN model to cartoonize a given image.
 
 <!-- dataset: multiple -->
 <!-- module-type: image-style-transfer -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/deeplabv3-mobilenetv2-ade20k/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-mobilenetv2-ade20k/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
+<!-- network-architecture: deeplab-mobilenetv2_ade20k_train -->
 <!-- dataset: ade20k -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/deeplabv3-mobilenetv2-float16/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-mobilenetv2-float16/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
+<!-- network-architecture: deeplab-mobilenetv2_coco_voc_trainval -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- language: en -->

--- a/assets/docs/sayakpaul/deeplabv3-mobilenetv2-int8/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-mobilenetv2-int8/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
+<!-- network-architecture: deeplab-mobilenetv2_coco_voc_trainval -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- language: en -->

--- a/assets/docs/sayakpaul/deeplabv3-mobilenetv2/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-mobilenetv2/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
+<!-- network-architecture: deeplab-mobilenetv2_coco_voc_trainval -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- language: en -->

--- a/assets/docs/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
+<!-- network-architecture: deeplab-mobilenetv2_dm05_coco_voc_trainval -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
+<!-- network-architecture: deeplab-mobilenetv2_dm05_coco_voc_trainval -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
+<!-- network-architecture: deeplab-mobilenetv2_dm05_coco_voc_trainval -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/deeplabv3-mobilenetv3-cityscapes/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-mobilenetv3-cityscapes/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv3_large_cityscapes_trainfine) -->
+<!-- network-architecture: deeplab-mobilenetv3_large_cityscapes_trainfine -->
 <!-- dataset: cityscapes -->
 <!-- fine-tunable: false -->
 <!-- language: en -->

--- a/assets/docs/sayakpaul/deeplabv3-xception65-ade20k/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-xception65-ade20k/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (xception65_ade20k_train) -->
+<!-- network-architecture: deeplab-xception65_ade20k_train -->
 <!-- dataset: ade20k -->
 <!-- fine-tunable: false -->
 <!-- language: en -->

--- a/assets/docs/sayakpaul/deeplabv3-xception65-cityscapes/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-xception65-cityscapes/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (xception65_cityscapes_trainfine) -->
+<!-- network-architecture: deeplab-xception65_cityscapes_trainfine -->
 <!-- dataset: cityscapes -->
 <!-- fine-tunable: false -->
 <!-- language: en -->

--- a/assets/docs/sayakpaul/deeplabv3-xception65/1.md
+++ b/assets/docs/sayakpaul/deeplabv3-xception65/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (xception65_coco_voc_trainaug) -->
+<!-- network-architecture: deeplab-xception65_coco_voc_trainaug -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/east-text-detector/1.md
+++ b/assets/docs/sayakpaul/east-text-detector/1.md
@@ -3,6 +3,6 @@ EAST model for text detection from natural scenes.
 
 <!-- dataset: multiple -->
 <!-- module-type: image-object-detection -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/mirnet-fixed/1.md
+++ b/assets/docs/sayakpaul/mirnet-fixed/1.md
@@ -3,6 +3,6 @@ MIRNet model to enhance a low-light image.
 
 <!-- dataset: lol -->
 <!-- module-type: image-super-resolution -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/mobilenetv2-coco/1.md
+++ b/assets/docs/sayakpaul/mobilenetv2-coco/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
+<!-- network-architecture: deeplab-mobilenetv2_coco_voc_trainval -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/sayakpaul/mobilenetv2-dm05-coco/1.md
+++ b/assets/docs/sayakpaul/mobilenetv2-dm05-coco/1.md
@@ -2,7 +2,7 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
+<!-- network-architecture: deeplab-mobilenetv2_dm05_coco_voc_trainval -->
 <!-- dataset: pascal-voc-2012 -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/see--/bert-uncased-tf2-qa/1.md
+++ b/assets/docs/see--/bert-uncased-tf2-qa/1.md
@@ -3,7 +3,7 @@ BERT[1] model for question answering finetuned on the Natural Questions dataset[
 
 <!-- asset-path: legacy -->
 <!-- module-type: text-question-answering -->
-<!-- network-architecture: Transformer -->
+<!-- network-architecture: transformer -->
 <!-- network-architecture: bert -->
 <!-- dataset: natural-questions -->
 <!-- language: en -->

--- a/assets/docs/svampeatlas/models/vision/classifier/fungi_mobile_V1/1.md
+++ b/assets/docs/svampeatlas/models/vision/classifier/fungi_mobile_V1/1.md
@@ -5,7 +5,7 @@ by the Danish Mycological Society.
 
 <!-- module-type: image-classification -->
 <!-- asset-path: legacy -->
-<!-- network-architecture: MobileNet V2 -->
+<!-- network-architecture: mobilenet-v2 -->
 <!-- fine-tunable: false -->
 <!-- format: hub -->
 <!-- interactive-model-name: mobile_mushroom_classifier -->

--- a/assets/docs/svampeatlas/models/vision/classifier/fungi_mobile_V1/2.md
+++ b/assets/docs/svampeatlas/models/vision/classifier/fungi_mobile_V1/2.md
@@ -5,7 +5,7 @@ by the Danish Mycological Society.
 
 <!-- asset-path: @visionkit/project_v/classifier/fungi_V1/3 -->
 <!-- module-type: image-classification -->
-<!-- network-architecture: MobileNet V2 -->
+<!-- network-architecture: mobilenet-v2 -->
 <!-- fine-tunable: false -->
 <!-- format: hub -->
 <!-- interactive-model-name: mobile_mushroom_classifier -->

--- a/assets/docs/svampeatlas/models/vision/embedder/fungi_V2/1.md
+++ b/assets/docs/svampeatlas/models/vision/embedder/fungi_V2/1.md
@@ -4,7 +4,7 @@ Mycological Society.
 
 <!-- module-type: image-feature-vector -->
 <!-- asset-path: legacy -->
-<!-- network-architecture: Inception V4 -->
+<!-- network-architecture: inception-v4 -->
 <!-- fine-tunable: false -->
 <!-- format: hub -->
 <!-- interactive-model-name: mushroom_recognizer_v2 -->

--- a/assets/docs/tulasiram58827/craft-text-detector/1.md
+++ b/assets/docs/tulasiram58827/craft-text-detector/1.md
@@ -4,7 +4,7 @@ CRAFT Model for text detection from natural scenes or documents.
 
 <!-- dataset: multiple -->
 <!-- module-type: image-text-detection -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->
 

--- a/assets/docs/tulasiram58827/fastspeech2/1.md
+++ b/assets/docs/tulasiram58827/fastspeech2/1.md
@@ -3,6 +3,6 @@ FastSpeech2: Fast and High-Quality End-to-End Text to Speech
 
 <!-- dataset: ljspeech -->
 <!-- module-type: audio-speech-synthesis -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/tulasiram58827/hifi-gan/1.md
+++ b/assets/docs/tulasiram58827/hifi-gan/1.md
@@ -3,7 +3,7 @@ HiFi-GAN: Generative Adversial Networks for Efficient and High Fidelity Speech S
 
 <!-- dataset: ljspeech -->
 <!-- module-type: audio-speech-synthesis -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->
 

--- a/assets/docs/tulasiram58827/keras-ocr/1.md
+++ b/assets/docs/tulasiram58827/keras-ocr/1.md
@@ -4,7 +4,7 @@ OCR Model created with CRNN architecture used to recognize text from image.
 
 <!-- dataset: multiple -->
 <!-- module-type: image-text-recognition -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->
 

--- a/assets/docs/tulasiram58827/keras-ocr/2.md
+++ b/assets/docs/tulasiram58827/keras-ocr/2.md
@@ -3,7 +3,7 @@ OCR Model created with CRNN architecture used to recognize text from image.
 
 <!-- dataset: multiple -->
 <!-- module-type: image-text-recognition -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->
 

--- a/assets/docs/tulasiram58827/melgan/1.md
+++ b/assets/docs/tulasiram58827/melgan/1.md
@@ -3,7 +3,7 @@ MelGAN: Generative Adversarial Networks for Conditional Waveform Synthesis
 
 <!-- dataset: ljspeech -->
 <!-- module-type: audio-speech-synthesis -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->
 

--- a/assets/docs/tulasiram58827/parallel_wavegan/1.md
+++ b/assets/docs/tulasiram58827/parallel_wavegan/1.md
@@ -3,6 +3,6 @@ Parallel WaveGAN: A FAST WAVEFORM GENERATION MODEL BASED ON GENERATIVE ADVERSARI
 
 <!-- dataset: ljspeech -->
 <!-- module-type: audio-speech-synthesis -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/tulasiram58827/rosetta/1.md
+++ b/assets/docs/tulasiram58827/rosetta/1.md
@@ -3,6 +3,6 @@ TFLite Model of Rosetta Text Recognition(OCR) Module(ResNet+CTC).
 
 <!-- dataset: multiple -->
 <!-- module-type: image-text-recognition -->
-<!-- network-architecture: Other -->
+<!-- network-architecture: other -->
 <!-- fine-tunable: false -->
 <!-- license: Apache-2.0 -->

--- a/assets/docs/vtab/models/cond-biggan/1.md
+++ b/assets/docs/vtab/models/cond-biggan/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by a class-conditional BigGAN discriminator.
 <!-- asset-path: https://storage.googleapis.com/vtab/cond-biggan/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: BigGAN -->
+<!-- network-architecture: biggan -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/exemplar/1.md
+++ b/assets/docs/vtab/models/exemplar/1.md
@@ -4,7 +4,7 @@ Visual representation obtained with Exemplar loss on ImageNet.
 <!-- asset-path: https://storage.googleapis.com/vtab/exemplar/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/jigsaw/1.md
+++ b/assets/docs/vtab/models/jigsaw/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by solving jigsaw puzzles on ImageNet.
 <!-- asset-path: https://storage.googleapis.com/vtab/jigsaw/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/relative-patch-location/1.md
+++ b/assets/docs/vtab/models/relative-patch-location/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by predicting relative patch location on ImageNet
 <!-- asset-path: https://storage.googleapis.com/vtab/relative-patch-location/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/rotation/1.md
+++ b/assets/docs/vtab/models/rotation/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by predicting rotation on ImageNet examples.
 <!-- asset-path: https://storage.googleapis.com/vtab/rotation/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/semi-exemplar-10/1.md
+++ b/assets/docs/vtab/models/semi-exemplar-10/1.md
@@ -5,7 +5,7 @@ labels and with an auxiliary Exemplar loss on all of the ImageNet examples.
 <!-- asset-path: https://storage.googleapis.com/vtab/semi-exemplar-10/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/semi-rotation-10/1.md
+++ b/assets/docs/vtab/models/semi-rotation-10/1.md
@@ -5,7 +5,7 @@ labels and with auxiliary Rotation loss on all of the ImageNet examples.
 <!-- asset-path: https://storage.googleapis.com/vtab/semi-rotation-10/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/sup-100/1.md
+++ b/assets/docs/vtab/models/sup-100/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by supervised training on ImageNet.
 <!-- asset-path: https://storage.googleapis.com/vtab/sup-100/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/sup-exemplar-100/1.md
+++ b/assets/docs/vtab/models/sup-exemplar-100/1.md
@@ -5,7 +5,7 @@ auxiliar Exemplar loss.
 <!-- asset-path: https://storage.googleapis.com/vtab/sup-exemplar-100/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/sup-rotation-100/1.md
+++ b/assets/docs/vtab/models/sup-rotation-100/1.md
@@ -5,7 +5,7 @@ auxiliar Rotation loss.
 <!-- asset-path: https://storage.googleapis.com/vtab/sup-rotation-100/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: ResNet50-v2 -->
+<!-- network-architecture: resnet50-v2 -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/uncond-biggan/1.md
+++ b/assets/docs/vtab/models/uncond-biggan/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by an unconditional BigGAN discriminator
 <!-- asset-path: https://storage.googleapis.com/vtab/uncond-biggan/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: BigGAN -->
+<!-- network-architecture: biggan -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/vae/1.md
+++ b/assets/docs/vtab/models/vae/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by training a VAE on ImageNet.
 <!-- asset-path: https://storage.googleapis.com/vtab/vae/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: VAE -->
+<!-- network-architecture: vae -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/wae-gan/1.md
+++ b/assets/docs/vtab/models/wae-gan/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by training a WAE with a GAN loss.
 <!-- asset-path: https://storage.googleapis.com/vtab/wae-gan/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: WAE -->
+<!-- network-architecture: wae -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/wae-mmd/1.md
+++ b/assets/docs/vtab/models/wae-mmd/1.md
@@ -4,7 +4,7 @@ Visual representation obtained by training a WAE with a MMD loss.
 <!-- asset-path: https://storage.googleapis.com/vtab/wae-mmd/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: WAE -->
+<!-- network-architecture: wae -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 

--- a/assets/docs/vtab/models/wae-ukl/1.md
+++ b/assets/docs/vtab/models/wae-ukl/1.md
@@ -5,7 +5,7 @@ matching loss.
 <!-- asset-path: https://storage.googleapis.com/vtab/wae-ukl/1.tar.gz -->
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- module-type: image-feature-vector -->
-<!-- network-architecture: WAE -->
+<!-- network-architecture: wae -->
 <!-- fine-tunable: true -->
 <!-- format: hub -->
 


### PR DESCRIPTION
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms.

We've introduced that the values of the `<!-- network-architecture: ... -->` Markdown tag need to be the id of an item in network_architecture.yaml. This PR fixes that for the remaining files and thus also fixes the validator.py test.
