### PR TITLE
Adding RegNetY to TFHub

### DIFF
--- a/assets/docs/adityakane2001/adityakane2001.md
+++ b/assets/docs/adityakane2001/adityakane2001.md
@@ -1,0 +1,14 @@
+# Publisher adityakane2001
+Aditya Kane
+
+[![Icon URL]](https://avatars.githubusercontent.com/u/64411306?v=4)
+
+## Details
+
+Aditya Kane   
+Junior at PICT, Pune   
+Interested in Computer Vision
+
+
+**GitHub:** [AdityaKane2001](https://github.com/AdityaKane2001)\
+**LinkedIn:** [Aditya Kane](https://www.linkedin.com/in/aditya-kane/)

--- a/assets/docs/adityakane2001/collections/regnety/1.md
+++ b/assets/docs/adityakane2001/collections/regnety/1.md
@@ -1,0 +1,33 @@
+# Collection adityakane2001/regnety/1
+
+Collection of RegNetY models trained on ImageNet-1k
+
+<!-- dataset: imagenet-ilsvrc-2012-cls -->
+<!-- task: image-classification -->
+
+## Overview
+
+This collection contains RegNetY<sup>[1]</sup> classifiers and feature extractors trained on ImageNet-1k<sup>[2]</sup>. They can be used for out-of-the box inference as well as fine-tuning. A detailed tutorial is available as a Colab Notebook at <sup>[3]</sup>. Codebase used for training these models is available here<sup>[4]</sup>.
+
+
+## Table of contents
+
+| Model Name    | Accuracy | Inference speed on K80 | Inference speed on V100 | FLOPs (Number of parameters) | Link                                                                                                                                                                 |
+|---------------|----------|------------------------|-------------------------|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| RegNetY 200MF | 67.54%   | 656.626 images/sec     | 591.734 images/sec      | 200MF (3.23 million)         | [Classifier](https://tfhub.dev/adityakane2001/regnety200mf_classification/1), [Feature Extractor](https://tfhub.dev/adityakane2001/regnety200mf_feature_extractor/1) |
+| RegNetY 400MF | 70.19%   | 433.874 images/sec     | 703.797 images/sec      | 400MF (4.05 million)         | [Classifier](https://tfhub.dev/adityakane2001/regnety400mf_classification/1), [Feature Extractor](https://tfhub.dev/adityakane2001/regnety400mf_feature_extractor/1) |
+| RegNetY 600MF | 73.18%   | 359.797 images/sec     | 921.560 images/sec      | 600MF (6.21 million)         | [Classifier](https://tfhub.dev/adityakane2001/regnety600mf_classification/1), [Feature Extractor](https://tfhub.dev/adityakane2001/regnety600mf_feature_extractor/1) |
+| RegNetY 800MF | 73.94%   | 306.270 images/sec     | 907.439 images/sec      | 800MF (6.5 million)          | [Classifier](https://tfhub.dev/adityakane2001/regnety800mf_classification/1), [Feature Extractor](https://tfhub.dev/adityakane2001/regnety800mf_feature_extractor/1) |
+
+
+
+MF signifies million floating point operations.
+
+Reported accuracies are measured on ImageNet-1k validation dataset.
+
+## References 
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).  
+[2] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+[3] [Colab tutorial](https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb)   
+[4] [AdityaKane2001/regnety](https://github.com/AdityaKane2001/regnety)

--- a/assets/docs/adityakane2001/models/regnety200mf_classification/1.md
+++ b/assets/docs/adityakane2001/models/regnety200mf_classification/1.md
@@ -1,0 +1,45 @@
+# Module adityakane2001/regnety200mf_classification/1
+
+RegNetY 200MF image classifier pretrained on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/ak-regnety-savedmodels/tars/regnety200mf_classification.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: regnety -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb -->
+
+## Overview
+
+This model is the implementation of  RegNetY<sup>[1]</sup>  in TensorFlow 2.5.
+
+## Using this model
+
+This model is a pretrained classifier on ImageNet-1k. This means that you can directly classify images over 1000 predefined classes.
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/adityakane2001/regnety200mf_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `height`,`width` and `batch_size` can be any value based on user's preference. `num_channels` must be 3.
+2. have pixel values in the range `[0, 255]`.
+
+Model outputs can be inferred based on mapping of integers to labels as in here<sup>[2]</sup>. 
+
+For downstream task that involves fine-tuning, it is recommended to use a feature extractor of this model. Fine tuning this model is explained in accompanying Colab notebook.
+
+Note that all images are resized to 224x224 inside the model itself. This means the heavylifting of resizing all images is delegated to the hardware accelerator.   
+This also implies that even though you may pass large images, they will be resized to 224x224. So passing large images will not result in a difference in performance.
+
+One known caveat of this implementation is as of TensorFlow 2.5, this model can run only on GPU or TPU and not CPU. This is because grouped convolutions used in this model are not supported on CPUs be TensorFlow. At the time of writing this, grouped convs are not functional at all in Keras with TensorFlow 2.6.0. You can track the progress on this [here](https://github.com/keras-team/keras/issues/15162).   
+
+## References
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).   
+[2] [imagenet_synset_to_human.json](https://github.com/AdityaKane2001/regnety/blob/main/regnety/config/imagenet_synset_to_human.json) 

--- a/assets/docs/adityakane2001/models/regnety200mf_feature_extractor/1.md
+++ b/assets/docs/adityakane2001/models/regnety200mf_feature_extractor/1.md
@@ -1,0 +1,48 @@
+# Module adityakane2001/regnety200mf_feature_extractor/1
+
+RegNetY 200MF feature extractor pretrained on ImageNet-1k.
+
+<!-- asset-path:  https://storage.googleapis.com/ak-regnety-savedmodels/tars/regnety200mf_feature_extractor.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: regnety -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb -->
+
+## Overview
+
+This is the implementation of  RegNetY<sup>[1]</sup>  in TensorFlow 2.5.
+
+## Using this model
+
+This model is pretrained on ImageNet-1k. Thus, it can be easily fine-tuned for a plethora of downstream tasks. 
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/adityakane2001/regnety200mf_feature_extractor/1", training=False), # Can be True
+    tf.keras.layers.GlobalAveragePooling(),
+    tf.keras.layers.Dense(num_classes)
+])
+
+model.compile(...)
+model.fit(...)
+```
+
+Inputs to the model must:
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `height`,`width` and `batch_size` can be any value based on user's preference. `num_channels` must be 3.
+2. have pixel values in the range `[0, 255]`.
+
+You can use with `training=False` or `training=True`. For a detailed guide on how to fine-tune these models, see here<sup>[2]</sup>. 
+
+Note that all images are resized to 224x224 inside the model itself. This means the heavylifting of resizing all images is delegated to the hardware accelerator.   
+This also implies that even though you may pass large images, they will be resized to 224x224. So passing large images will not result in a difference in performance.
+
+One known caveat of this implementation is as of TensorFlow 2.5, this model can run only on GPU or TPU and not CPU. This is because grouped convolutions used in this model are not supported on CPUs be TensorFlow. At the time of writing this, grouped convs are not functional at all in Keras with TensorFlow 2.6.0. You can track the progress on this [here](https://github.com/keras-team/keras/issues/15162).   
+  
+
+## References
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).   
+[2] [Colab Notebook](https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb)

--- a/assets/docs/adityakane2001/models/regnety400mf_classification/1.md
+++ b/assets/docs/adityakane2001/models/regnety400mf_classification/1.md
@@ -1,0 +1,46 @@
+# Module adityakane2001/regnety400mf_classification/1
+
+RegNetY 400MF image classifier pretrained on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/ak-regnety-savedmodels/tars/regnety400mf_classification.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: regnety -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb -->
+
+## Overview
+
+This model is the implementation of  RegNetY<sup>[1]</sup>  in TensorFlow 2.5.
+
+## Using this model
+
+This model is a pretrained classifier on ImageNet-1k. This means that you can directly classify images over 1000 predefined classes.
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/adityakane2001/regnety400mf_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `height`,`width` and `batch_size` can be any value based on user's preference. `num_channels` must be 3.
+2. have pixel values in the range `[0, 255]`.
+
+Model outputs can be inferred based on mapping of integers to labels as in here<sup>[2]</sup>. 
+
+For downstream task that involves fine-tuning, it is recommended to use a feature extractor of this model. Fine tuning this model is explained in accompanying Colab notebook.
+
+Note that all images are resized to 224x224 inside the model itself. This means the heavylifting of resizing all images is delegated to the hardware accelerator.   
+This also implies that even though you may pass large images, they will be resized to 224x224. So passing large images will not result in a difference in performance.
+
+One known caveat of this implementation is as of TensorFlow 2.5, this model can run only on GPU or TPU and not CPU. This is because grouped convolutions used in this model are not supported on CPUs be TensorFlow. At the time of writing this, grouped convs are not functional at all in Keras with TensorFlow 2.6.0. You can track the progress on this [here](https://github.com/keras-team/keras/issues/15162).   
+  
+
+## References
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).   
+[2] [imagenet_synset_to_human.json](https://github.com/AdityaKane2001/regnety/blob/main/regnety/config/imagenet_synset_to_human.json) 

--- a/assets/docs/adityakane2001/models/regnety400mf_feature_extractor/1.md
+++ b/assets/docs/adityakane2001/models/regnety400mf_feature_extractor/1.md
@@ -1,0 +1,48 @@
+# Module adityakane2001/regnety400mf_feature_extractor/1
+
+RegNetY 400MF feature extractor pretrained on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/ak-regnety-savedmodels/tars/regnety400mf_feature_extractor.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: regnety -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb -->
+
+## Overview
+
+This is the implementation of  RegNetY<sup>[1]</sup>  in TensorFlow 2.5.
+
+## Using this model
+
+This model is pretrained on ImageNet-1k. Thus, it can be easily fine-tuned for a plethora of downstream tasks. 
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/adityakane2001/regnety400mf_feature_extractor/1", training=False), # Can be True
+    tf.keras.layers.GlobalAveragePooling(),
+    tf.keras.layers.Dense(num_classes)
+])
+
+model.compile(...)
+model.fit(...)
+```
+
+Inputs to the model must:
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `height`,`width` and `batch_size` can be any value based on user's preference. `num_channels` must be 3.
+2. have pixel values in the range `[0, 255]`.
+
+You can use with `training=False` or `training=True`. For a detailed guide on how to fine-tune these models, see here<sup>[2]</sup>. 
+
+Note that all images are resized to 224x224 inside the model itself. This means the heavylifting of resizing all images is delegated to the hardware accelerator.   
+This also implies that even though you may pass large images, they will be resized to 224x224. So passing large images will not result in a difference in performance.
+
+One known caveat of this implementation is as of TensorFlow 2.5, this model can run only on GPU or TPU and not CPU. This is because grouped convolutions used in this model are not supported on CPUs be TensorFlow. At the time of writing this, grouped convs are not functional at all in Keras with TensorFlow 2.6.0. You can track the progress on this [here](https://github.com/keras-team/keras/issues/15162).   
+  
+
+## References
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).   
+[2] [Colab Notebook](https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb)

--- a/assets/docs/adityakane2001/models/regnety600mf_classification/1.md
+++ b/assets/docs/adityakane2001/models/regnety600mf_classification/1.md
@@ -1,0 +1,46 @@
+# Module adityakane2001/regnety600mf_classification/1
+
+RegNetY 600MF image classifier pretrained on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/ak-regnety-savedmodels/tars/regnety600mf_classification.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: regnety -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb -->
+
+## Overview
+
+This model is the implementation of  RegNetY<sup>[1]</sup>  in TensorFlow 2.5.
+
+## Using this model
+
+This model is a pretrained classifier on ImageNet-1k. This means that you can directly classify images over 1000 predefined classes.
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/adityakane2001/regnety600mf_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `height`,`width` and `batch_size` can be any value based on user's preference. `num_channels` must be 3.
+2. have pixel values in the range `[0, 255]`.
+
+Model outputs can be inferred based on mapping of integers to labels as in here<sup>[2]</sup>. 
+
+For downstream task that involves fine-tuning, it is recommended to use a feature extractor of this model. Fine tuning this model is explained in accompanying Colab notebook.
+
+Note that all images are resized to 224x224 inside the model itself. This means the heavylifting of resizing all images is delegated to the hardware accelerator.   
+This also implies that even though you may pass large images, they will be resized to 224x224. So passing large images will not result in a difference in performance.
+
+One known caveat of this implementation is as of TensorFlow 2.5, this model can run only on GPU or TPU and not CPU. This is because grouped convolutions used in this model are not supported on CPUs be TensorFlow. At the time of writing this, grouped convs are not functional at all in Keras with TensorFlow 2.6.0. You can track the progress on this [here](https://github.com/keras-team/keras/issues/15162).   
+  
+
+## References
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).   
+[2] [imagenet_synset_to_human.json](https://github.com/AdityaKane2001/regnety/blob/main/regnety/config/imagenet_synset_to_human.json) 

--- a/assets/docs/adityakane2001/models/regnety600mf_feature_extractor/1.md
+++ b/assets/docs/adityakane2001/models/regnety600mf_feature_extractor/1.md
@@ -1,0 +1,48 @@
+# Module adityakane2001/regnety600mf_feature_extractor/1
+
+RegNetY 600MF feature extractor pretrained on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/ak-regnety-savedmodels/tars/regnety600mf_feature_extractor.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: regnety -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb -->
+
+## Overview
+
+This is the implementation of  RegNetY<sup>[1]</sup>  in TensorFlow 2.5.
+
+## Using this model
+
+This model is pretrained on ImageNet-1k. Thus, it can be easily fine-tuned for a plethora of downstream tasks. 
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/adityakane2001/regnety600mf_feature_extractor/1", training=False), # Can be True
+    tf.keras.layers.GlobalAveragePooling(),
+    tf.keras.layers.Dense(num_classes)
+])
+
+model.compile(...)
+model.fit(...)
+```
+
+Inputs to the model must:
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `height`,`width` and `batch_size` can be any value based on user's preference. `num_channels` must be 3.
+2. have pixel values in the range `[0, 255]`.
+
+You can use with `training=False` or `training=True`. For a detailed guide on how to fine-tune these models, see here<sup>[2]</sup>. 
+
+Note that all images are resized to 224x224 inside the model itself. This means the heavylifting of resizing all images is delegated to the hardware accelerator.   
+This also implies that even though you may pass large images, they will be resized to 224x224. So passing large images will not result in a difference in performance.
+
+One known caveat of this implementation is as of TensorFlow 2.5, this model can run only on GPU or TPU and not CPU. This is because grouped convolutions used in this model are not supported on CPUs be TensorFlow. At the time of writing this, grouped convs are not functional at all in Keras with TensorFlow 2.6.0. You can track the progress on this [here](https://github.com/keras-team/keras/issues/15162).   
+  
+
+## References
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).   
+[2] [Colab Notebook](https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb)

--- a/assets/docs/adityakane2001/models/regnety800mf_classification/1.md
+++ b/assets/docs/adityakane2001/models/regnety800mf_classification/1.md
@@ -1,0 +1,46 @@
+# Module adityakane2001/regnety800mf_classification/1
+
+RegNetY 800MF image classifier pretrained on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/ak-regnety-savedmodels/tars/regnety800mf_classification.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: regnety -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb -->
+
+## Overview
+
+This model is the implementation of  RegNetY<sup>[1]</sup>  in TensorFlow 2.5.
+
+## Using this model
+
+This model is a pretrained classifier on ImageNet-1k. This means that you can directly classify images over 1000 predefined classes.
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/adityakane2001/regnety800mf_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `height`,`width` and `batch_size` can be any value based on user's preference. `num_channels` must be 3.
+2. have pixel values in the range `[0, 255]`.
+
+Model outputs can be inferred based on mapping of integers to labels as in here<sup>[2]</sup>. 
+
+For downstream task that involves fine-tuning, it is recommended to use a feature extractor of this model. Fine tuning this model is explained in accompanying Colab notebook.
+
+Note that all images are resized to 224x224 inside the model itself. This means the heavylifting of resizing all images is delegated to the hardware accelerator.   
+This also implies that even though you may pass large images, they will be resized to 224x224. So passing large images will not result in a difference in performance.
+
+One known caveat of this implementation is as of TensorFlow 2.5, this model can run only on GPU or TPU and not CPU. This is because grouped convolutions used in this model are not supported on CPUs be TensorFlow. At the time of writing this, grouped convs are not functional at all in Keras with TensorFlow 2.6.0. You can track the progress on this [here](https://github.com/keras-team/keras/issues/15162).   
+  
+
+## References
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).   
+[2] [imagenet_synset_to_human.json](https://github.com/AdityaKane2001/regnety/blob/main/regnety/config/imagenet_synset_to_human.json) 

--- a/assets/docs/adityakane2001/models/regnety800mf_feature_extractor/1.md
+++ b/assets/docs/adityakane2001/models/regnety800mf_feature_extractor/1.md
@@ -1,0 +1,48 @@
+# Module adityakane2001/regnety800mf_feature_extractor/1
+
+RegNetY 800MF feature extractor pretrained on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/ak-regnety-savedmodels/tars/regnety800mf_feature_extractor.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: regnety -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb -->
+
+## Overview
+
+This is the implementation of  RegNetY<sup>[1]</sup>  in TensorFlow 2.5.
+
+## Using this model
+
+This model is pretrained on ImageNet-1k. Thus, it can be easily fine-tuned for a plethora of downstream tasks. 
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/adityakane2001/regnety800mf_feature_extractor/1", training=False), # Can be True
+    tf.keras.layers.GlobalAveragePooling(),
+    tf.keras.layers.Dense(num_classes)
+])
+
+model.compile(...)
+model.fit(...)
+```
+
+Inputs to the model must:
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `height`,`width` and `batch_size` can be any value based on user's preference. `num_channels` must be 3.
+2. have pixel values in the range `[0, 255]`.
+
+You can use with `training=False` or `training=True`. For a detailed guide on how to fine-tune these models, see here<sup>[2]</sup>.  
+
+Note that all images are resized to 224x224 inside the model itself. This means the heavylifting of resizing all images is delegated to the hardware accelerator.   
+This also implies that even though you may pass large images, they will be resized to 224x224. So passing large images will not result in a difference in performance.
+
+One known caveat of this implementation is as of TensorFlow 2.5, this model can run only on GPU or TPU and not CPU. This is because grouped convolutions used in this model are not supported on CPUs be TensorFlow. At the time of writing this, grouped convs are not functional at all in Keras with TensorFlow 2.6.0. You can track the progress on this [here](https://github.com/keras-team/keras/issues/15162).   
+  
+
+## References
+
+[1] [Designing Network Design Spaces by Radosavovic et al](https://arxiv.org/abs/2003.13678).   
+[2] [Colab Notebook](https://colab.research.google.com/github/AdityaKane2001/regnety/blob/temp_notebook/RegNetY_models_in_TF_2_5.ipynb)

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -111,6 +111,8 @@ values:
     display_name: PNASNet-5 (large)
   - id: progressive-gan
     display_name: Progressive GAN
+  - id: regnety
+    display_name: RegNetY
   - id: reqa
     display_name: ReQA
   - id: resnet


### PR DESCRIPTION
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

Adding RegNetY-{200, 400, 600, 800}MF to TFHub. 

Directory structure as follows:
```
assets/docs/adityakane2001
│   adityakane2001.md
│
├───collections
│   └───regnety
│           1.md
└───models
    ├───regnety200mf_classification
    │       1.md
    ├───regnety200mf_feature_extractor
    │       1.md
    ├───regnety400mf_classification
    │       1.md
    ├───regnety400mf_feature_extractor
    │       1.md
    ├───regnety600mf_classification
    │       1.md
    ├───regnety600mf_feature_extractor
    │       1.md
    ├───regnety800mf_classification
    │       1.md
    └───regnety800mf_feature_extractor
            1.md
```

The links `[3] [Colab tutorial]()` and `<!-- colab :  -->`  throughout the readme files will be filled in shortly. 


/cc @sayakpaul  @MorganR 