### PR TITLE
Export Finetuned wav2vec2 model

### DIFF
--- a/assets/docs/vasudevgupta7/models/wav2vec2-960h/1.md
+++ b/assets/docs/vasudevgupta7/models/wav2vec2-960h/1.md
@@ -1,0 +1,34 @@
+# Module vasudevgupta7/wav2vec2-960h/1
+
+This model is fine-tuned on 960h of LibriSpeech dataset for Automatic Speech Recognition. For fine-tuning, base layer was initialized from pre-trained [wav2vec2](https://tfhub.dev/vasudevgupta7/wav2vec2/1)).
+
+<!-- asset-path:  https://storage.googleapis.com/gsoc-weights/wav2vec2-960h/saved-model.tar.gz -->
+<!-- task: audio-stt -->
+<!-- network-architecture: wav2vec2-960h -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/vasudevgupta7/gsoc-wav2vec2/blob/main/notebooks/librispeech_saved_model_evaluation.ipynb -->
+
+## Overview
+
+This model is TensorFlow equivalent of PyTorch [`facebook/wav2vec2-base-960h`](https://huggingface.co/facebook/wav2vec2-base-960h). It was published in [1].
+
+**How to use this model?**
+
+You can use this model directly for inference.
+
+```python
+import tensorflow as tf
+import tensorflow_hub as hub
+
+model = hub.KerasLayer("https://tfhub.dev/vasudevgupta7/wav2vec2-960h/1")
+# For using this model, it's important to set `jit_compile=True` on GPUs/CPUs
+# as some operations in this model (i.e. group-convolutions) are unsupported without it
+model = tf.function(model, jit_compile=True)
+```
+
+References
+--------------
+[1] [wav2vec 2.0: A Framework for Self-Supervised Learning of Speech Representations](https://arxiv.org/abs/2006.11477).

--- a/assets/docs/vasudevgupta7/models/wav2vec2-960h/1.md
+++ b/assets/docs/vasudevgupta7/models/wav2vec2-960h/1.md
@@ -1,19 +1,30 @@
 # Module vasudevgupta7/wav2vec2-960h/1
 
-This model is fine-tuned on 960h of LibriSpeech dataset for Automatic Speech Recognition. For fine-tuning, base layer was initialized from pre-trained [wav2vec2](https://tfhub.dev/vasudevgupta7/wav2vec2/1)).
+This model is fine-tuned on 960h of LibriSpeech dataset for Automatic Speech Recognition. For fine-tuning, the base layer was initialized from pre-trained [wav2vec2](https://tfhub.dev/vasudevgupta7/wav2vec2/1)).
 
-<!-- asset-path:  https://storage.googleapis.com/gsoc-weights/wav2vec2-960h/saved-model.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/gsoc-weights/wav2vec2-960h/saved-model.tar.gz -->
 <!-- task: audio-stt -->
-<!-- network-architecture: wav2vec2-960h -->
+<!-- network-architecture: wav2vec2 -->
 <!-- format: saved_model_2 -->
 <!-- fine-tunable: false -->
 <!-- license: apache-2.0 -->
 <!-- language: en -->
-<!-- colab: https://colab.research.google.com/github/vasudevgupta7/gsoc-wav2vec2/blob/main/notebooks/librispeech_saved_model_evaluation.ipynb -->
+<!-- colab: https://colab.research.google.com/github/vasudevgupta7/gsoc-wav2vec2/blob/main/notebooks/librispeech_evaluation_WER_6.ipynb -->
 
 ## Overview
 
 This model is TensorFlow equivalent of PyTorch [`facebook/wav2vec2-base-960h`](https://huggingface.co/facebook/wav2vec2-base-960h). It was published in [1].
+
+This model gave us `6% WER` on the `test-clean` split of the LibriSpeech dataset. We are getting 3% more WER with the `TF SavedModel` than what is reported [here](https://huggingface.co/facebook/wav2vec2-base-960h) as we are evaluating the model with the padded sequences (i.e. padding/restricting sequence length to 246000).
+
+Cons of padding/restricting sequences to constant length while evaluating `Wav2Vec2` model:
+
+1. While predicting, the model won't get complete speech for the sequences which are very long. This can result in bad predictions or prediction of truncated sequences which will result in poor metric value
+2. `Wav2Vec2` model doesn't accept `attention_mask/padding_mask` as an argument and hence any padding on small sequences will result in poor metrics.
+
+Note: This model accepts only sequences with a length of 246000 as `TF SavedModel` expects a fixed shape input during inference.
+
+In case you are interested in evaluating the model with variable sequence lengths and checking if this model can give us `3% WER`, please check out [this notebook](https://colab.research.google.com/github/vasudevgupta7/gsoc-wav2vec2/blob/main/notebooks/librispeech_evaluation_WER_3.ipynb).
 
 **How to use this model?**
 

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -195,6 +195,8 @@ values:
     display_name: WAE
   - id: wav2vec2
     display_name: wav2vec2
+  - id: wav2vec2-960h
+    display_name: wav2vec2-960h
   - id: wide-resnet-40-8
     display_name: Wide-ResNet-40-8
   - id: word2vec-skip-gram

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -195,8 +195,6 @@ values:
     display_name: WAE
   - id: wav2vec2
     display_name: wav2vec2
-  - id: wav2vec2-960h
-    display_name: wav2vec2-960h
   - id: wide-resnet-40-8
     display_name: Wide-ResNet-40-8
   - id: word2vec-skip-gram


### PR DESCRIPTION
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

This PR adds fine-tuned wav2vec2 model to TFHub. This model can directly be used for inference. It achieved `~ 6%` WER on LibriSpeech test-clean dataset.

@MorganR @sayakpaul 
