### PR TITLE
add Wav2Vec2 robust & xlsr-53 ckpts

### DIFF
--- a/assets/docs/vasudevgupta7/models/wav2vec2-robust/1.md
+++ b/assets/docs/vasudevgupta7/models/wav2vec2-robust/1.md
@@ -1,0 +1,54 @@
+# Module vasudevgupta7/wav2vec2-robust/1
+
+Pre-trained speech model (without any head) from Facebook for Automatic Speech Recognition
+
+<!-- asset-path: https://storage.googleapis.com/gsoc-weights/wav2vec2_robust.tar.gz -->
+<!-- task: audio-stt -->
+<!-- network-architecture: wav2vec2 -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/tensorflow/hub/blob/master/examples/colab/wav2vec2_saved_model_finetuning.ipynb -->
+
+
+## Overview
+
+This model is TensorFlow equivalent of PyTorch [`facebook/wav2vec2-large-robust`](https://huggingface.co/facebook/wav2vec2-large-robust). It was published in [1].
+
+**How to use this model?**
+
+Add randomly initalized LM head over the top of pre-trained model & fine-tune the whole model.
+
+```python
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# For using this pre-trained model for training, pass `trainable=True` in `hub.KerasLayer`
+pretrained_layer = hub.KerasLayer("https://tfhub.dev/vasudevgupta7/wav2vec2-robust/1", trainable=True)
+
+VOCAB_SIZE = 32
+# model signature expects sequences of constant length of 246000
+WAV_DATA_POINTS = 246000
+
+# Let's wrap all the layers into `tf.keras.Model` using TensorFlow's Functional API
+speech = tf.keras.Input(shape=(WAV_DATA_POINTS,))
+attention_mask = tf.keras.Input(shape=(WAV_DATA_POINTS,))
+hidden_states = pretrained_layer((speech, attention_mask))
+outputs = tf.keras.layers.Dense(VOCAB_SIZE)(hidden_states)
+model = tf.keras.Model(inputs=(speech, attention_mask), outputs=outputs)
+
+# For using this model, it's important to set `jit_compile=True` on GPUs/CPUs
+# as some operations in this model (i.e. group-convolutions) are unsupported without it
+@tf.function(jit_compile=True)
+def forward(speech, attention_mask):
+    return model((speech, attention_mask), training=True)
+
+# Now, this model can trained like any other TensorFlow model
+```
+
+Note: This model shouldn't be directly used for inference. Language Model (LM) head should be added on the top of this model & it should be fine-tuned for downstream tasks like speech -> text.
+
+References
+--------------
+[1] [Robust wav2vec 2.0: Analyzing Domain Shift in Self-Supervised Pre-Training](https://arxiv.org/abs/2104.01027).

--- a/assets/docs/vasudevgupta7/models/wav2vec2-xlsr-53/1.md
+++ b/assets/docs/vasudevgupta7/models/wav2vec2-xlsr-53/1.md
@@ -1,0 +1,54 @@
+# Module vasudevgupta7/wav2vec2-xlsr-53/1
+
+Pre-trained speech model (without any head) from Facebook for Automatic Speech Recognition
+
+<!-- asset-path: https://storage.googleapis.com/gsoc-weights/wav2vec2_xlsr_53.tar.gz -->
+<!-- task: audio-stt -->
+<!-- network-architecture: wav2vec2 -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- language: en -->
+<!-- colab: https://colab.research.google.com/github/tensorflow/hub/blob/master/examples/colab/wav2vec2_saved_model_finetuning.ipynb -->
+
+
+## Overview
+
+This model is TensorFlow equivalent of PyTorch [`facebook/wav2vec2-large-xlsr-53`](https://huggingface.co/facebook/wav2vec2-large-xlsr-53). It was published in [1].
+
+**How to use this model?**
+
+Add randomly initalized LM head over the top of pre-trained model & fine-tune the whole model.
+
+```python
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# For using this pre-trained model for training, pass `trainable=True` in `hub.KerasLayer`
+pretrained_layer = hub.KerasLayer("https://tfhub.dev/vasudevgupta7/wav2vec2-xlsr-53/1", trainable=True)
+
+VOCAB_SIZE = 32
+# model signature expects sequences of constant length of 246000
+WAV_DATA_POINTS = 246000
+
+# Let's wrap all the layers into `tf.keras.Model` using TensorFlow's Functional API
+speech = tf.keras.Input(shape=(WAV_DATA_POINTS,))
+attention_mask = tf.keras.Input(shape=(WAV_DATA_POINTS,))
+hidden_states = pretrained_layer((speech, attention_mask))
+outputs = tf.keras.layers.Dense(VOCAB_SIZE)(hidden_states)
+model = tf.keras.Model(inputs=(speech, attention_mask), outputs=outputs)
+
+# For using this model, it's important to set `jit_compile=True` on GPUs/CPUs
+# as some operations in this model (i.e. group-convolutions) are unsupported without it
+@tf.function(jit_compile=True)
+def forward(speech, attention_mask):
+    return model((speech, attention_mask), training=True)
+
+# Now, this model can trained like any other TensorFlow model
+```
+
+Note: This model shouldn't be directly used for inference. Language Model (LM) head should be added on the top of this model & it should be fine-tuned for downstream tasks like speech -> text. Complete fine-tuning workflow is shown in the accompanying notebook.
+
+References
+--------------
+[1] [Unsupervised Cross-lingual Representation Learning for Speech Recognition](https://arxiv.org/abs/2006.13979).


### PR DESCRIPTION
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

Please provide only one commit. You can continuously add changes to your latest commit using [`git commit --amend`](https://stackoverflow.com/q/179123) followed by `git push -f` to update your remote branch. Alternatively, [here](https://stackoverflow.com/q/5189560) are details on how to squash multiple commits into one commit.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.


This PR add TensorFlow equivalents of [`facebook/wav2vec2-large-xlsr-53`](https://huggingface.co/facebook/wav2vec2-large-xlsr-53) & [`facebook/wav2vec2-large-robust`](https://huggingface.co/facebook/wav2vec2-large-robust) to TFHub.

@MorganR @sayakpaul 