### PR TITLE
Vision Transformers for classification and transfer learning

### DIFF
--- a/assets/docs/sayakpaul/collections/vision_transformer/1.md
+++ b/assets/docs/sayakpaul/collections/vision_transformer/1.md
@@ -1,0 +1,60 @@
+# Collection sayakpaul/vit/1
+
+Collection of new Vision Transformer models fine-tuned on ImageNet-1k.
+
+## Overview
+
+This collection contains seven different Vision Transformer [1] models that were fine-tuned 
+on the ImageNet-1k dataset [2]. For more details on the training protocols, please follow [3].
+The authors of [3] open-sourced about 50k different variants of Vision Transformer models in JAX. 
+This collection contains seven of the best ImageNet-1k models from that pool. 
+
+The models contained in this collection were converted from the original model classes and
+weights [4] using the `jax2tf` tool [5]. For more details on the conversion process, please
+follow [this notebook](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb).
+**Using this notebook, one should be able to take a model (that is not already a part of
+this collection) from [4] and convert that to a TensorFlow SavedModel.**
+
+The criteria that were used to select the models included in this collection can be found
+in [this notebook](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/model-selector.ipynb). 
+
+## About the models
+
+Models included in this collection have two variants: (1) off-the-shelf inference for image
+classification, (2) fine-tuning on downstream tasks. These models are accompanied by
+Colab Notebooks for demonstration purposes. 
+
+A huge thanks to the authors of [3] for their open-sourcing efforts and for making the models
+as reproducible as possible.
+
+### Image classifiers
+
+* [ViT-S16](https://tfhub.dev/sayakpaul/vit_s16_classification/1)
+* [ViT-B16](https://tfhub.dev/sayakpaul/vit_b16_classification/1)
+* [ViT-B32](https://tfhub.dev/sayakpaul/vit_b32_classification/1)
+* [ViT-L16](https://tfhub.dev/sayakpaul/vit_l16_classification/1)
+* [ViT-R26-S32 (light augmentation)](https://tfhub.dev/sayakpaul/vit_r26_s32_lightaug_classification/1)
+* [ViT-R26-S32 (medium augmentation)](https://tfhub.dev/sayakpaul/vit_r26_s32_medaug_classification/1)
+* [ViT-R50-L32](https://tfhub.dev/sayakpaul/vit_r50_l32_classification/1)
+
+### Feature extractors
+
+* [ViT-S16]
+* [ViT-B16]
+* [ViT-B32]
+* [ViT-L16]
+* [ViT-R26-S32 (light augmentation)]
+* [ViT-R26-S32 (medium augmentation)]
+* [ViT-R50-L32]
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929)
+
+[2] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)
+
+[3] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [jax2tf tool](https://github.com/google/jax/tree/main/jax/experimental/jax2tf/)

--- a/assets/docs/sayakpaul/collections/vision_transformer/1.md
+++ b/assets/docs/sayakpaul/collections/vision_transformer/1.md
@@ -33,6 +33,7 @@ as reproducible as possible.
 ### Image classifiers
 
 * [ViT-S16](https://tfhub.dev/sayakpaul/vit_s16_classification/1)
+* [ViT-B8](https://tfhub.dev/sayakpaul/vit_b8_classification/1)
 * [ViT-B16](https://tfhub.dev/sayakpaul/vit_b16_classification/1)
 * [ViT-B32](https://tfhub.dev/sayakpaul/vit_b32_classification/1)
 * [ViT-L16](https://tfhub.dev/sayakpaul/vit_l16_classification/1)
@@ -43,6 +44,7 @@ as reproducible as possible.
 ### Feature extractors
 
 * [ViT-S16](https://tfhub.dev/sayakpaul/vit_s16_fe/1)
+* [ViT-B8](https://tfhub.dev/sayakpaul/vit_b8_fe/1)
 * [ViT-B16](https://tfhub.dev/sayakpaul/vit_b16_fe/1)
 * [ViT-B32](https://tfhub.dev/sayakpaul/vit_b32_fe/1)
 * [ViT-L16](https://tfhub.dev/sayakpaul/vit_l16_fe/1)

--- a/assets/docs/sayakpaul/collections/vision_transformer/1.md
+++ b/assets/docs/sayakpaul/collections/vision_transformer/1.md
@@ -2,6 +2,9 @@
 
 Collection of new Vision Transformer models fine-tuned on ImageNet-1k.
 
+<!-- dataset: imagenet-ilsvrc-2012-cls -->
+<!-- task: image-classification -->
+
 ## Overview
 
 This collection contains seven different Vision Transformer [1] models that were fine-tuned 

--- a/assets/docs/sayakpaul/collections/vision_transformer/1.md
+++ b/assets/docs/sayakpaul/collections/vision_transformer/1.md
@@ -30,6 +30,21 @@ Colab Notebooks for demonstration purposes.
 A huge thanks to the authors of [3] for their open-sourcing efforts and for making the models
 as reproducible as possible.
 
+The table below provides a performance summary:
+
+| **Model** | **Top-1 Accuracy (%)** |
+|:---:|:---:|
+| B/8 | 85.948 |
+| L/16 | 85.716 |
+| B/16 | 84.018 |
+| R50-L/32 | 83.784 |
+| R26-S/32 (light aug) | 80.944 |
+| R26-S/32 (medium aug) | 80.462 |
+| S/16 | 80.462 |
+| B/32 | 79.436 |
+
+Note that the top-1 accuracy is reported on ImageNet-1k validation set.
+
 ### Image classifiers
 
 * [ViT-S16](https://tfhub.dev/sayakpaul/vit_s16_classification/1)

--- a/assets/docs/sayakpaul/collections/vision_transformer/1.md
+++ b/assets/docs/sayakpaul/collections/vision_transformer/1.md
@@ -42,13 +42,13 @@ as reproducible as possible.
 
 ### Feature extractors
 
-* [ViT-S16]
-* [ViT-B16]
-* [ViT-B32]
-* [ViT-L16]
-* [ViT-R26-S32 (light augmentation)]
-* [ViT-R26-S32 (medium augmentation)]
-* [ViT-R50-L32]
+* [ViT-S16](https://tfhub.dev/sayakpaul/vit_s16_fe/1)
+* [ViT-B16](https://tfhub.dev/sayakpaul/vit_b16_fe/1)
+* [ViT-B32](https://tfhub.dev/sayakpaul/vit_b32_fe/1)
+* [ViT-L16](https://tfhub.dev/sayakpaul/vit_l16_fe/1)
+* [ViT-R26-S32 (light augmentation)](https://tfhub.dev/sayakpaul/vit_r26_s32_lightaug_fe/1)
+* [ViT-R26-S32 (medium augmentation)](https://tfhub.dev/sayakpaul/vit_r26_s32_medaug_fe/1)
+* [ViT-R50-L32](https://tfhub.dev/sayakpaul/vit_r50_l32_fe/1)
 
 ## References
 

--- a/assets/docs/sayakpaul/collections/vision_transformer/1.md
+++ b/assets/docs/sayakpaul/collections/vision_transformer/1.md
@@ -1,4 +1,4 @@
-# Collection sayakpaul/vit/1
+# Collection sayakpaul/vision_transformer/1
 
 Collection of new Vision Transformer models fine-tuned on ImageNet-1k.
 
@@ -7,7 +7,7 @@ Collection of new Vision Transformer models fine-tuned on ImageNet-1k.
 
 ## Overview
 
-This collection contains seven different Vision Transformer [1] models that were fine-tuned 
+This collection contains eight different Vision Transformer [1] models that were fine-tuned 
 on the ImageNet-1k dataset [2]. For more details on the training protocols, please follow [3].
 The authors of [3] open-sourced about 50k different variants of Vision Transformer models in JAX. 
 This collection contains seven of the best ImageNet-1k models from that pool. 

--- a/assets/docs/sayakpaul/vit_b16_classification/1.md
+++ b/assets/docs/sayakpaul/vit_b16_classification/1.md
@@ -1,0 +1,49 @@
+# Module sayakpaul/vit_b16_classification/1
+
+Vision Transformer (ViT) fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/B_16-i21k-300ep-lr_0.001-aug_medium2-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/classification.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type B-16 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_b16_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+The model also has a [feature extractor variant](https://tfhub.dev/sayakpaul/vit_b16_fe/1) which should be used for the purposes of transfer learning. For more details, please refer to the accompanying Colab Notebook. _**Please make sure the inputs are in [-1, 1] range as opposed to [0, 1].**_
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_b16_fe/1.md
+++ b/assets/docs/sayakpaul/vit_b16_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/vit_b16_fe/1
+
+Vision Transformer feature extractor fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/B_16-i21k-300ep-lr_0.001-aug_medium2-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type B-16 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_b16_fe/1", trainable=True)
+])
+...
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_b32_classification/1.md
+++ b/assets/docs/sayakpaul/vit_b32_classification/1.md
@@ -1,0 +1,49 @@
+# Module sayakpaul/vit_b32_classification/1
+
+Vision Transformer (ViT) fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/B_32-i21k-300ep-lr_0.001-aug_medium1-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/classification.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type B-32 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_b32_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+The model also has a [feature extractor variant](https://tfhub.dev/sayakpaul/vit_b32_fe/1) which should be used for the purposes of transfer learning. For more details, please refer to the accompanying Colab Notebook. _**Please make sure the inputs are in [-1, 1] range as opposed to [0, 1].**_
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_b32_fe/1.md
+++ b/assets/docs/sayakpaul/vit_b32_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/vit_b32_fe/1
+
+Vision Transformer feature extractor fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/B_32-i21k-300ep-lr_0.001-aug_medium1-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type B-32 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_b32_fe/1", trainable=True)
+])
+...
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_b8_classification/1.md
+++ b/assets/docs/sayakpaul/vit_b8_classification/1.md
@@ -1,0 +1,49 @@
+# Module sayakpaul/vit_b8_classification/1
+
+Vision Transformer (ViT) fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/B_8-i21k-300ep-lr_0.001-aug_medium2-wd_0.1-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.01-res_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/classification.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type B-8 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_b8_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+The model also has a [feature extractor variant](https://tfhub.dev/sayakpaul/vit_b8_fe/1) which should be used for the purposes of transfer learning. For more details, please refer to the accompanying Colab Notebook. _**Please make sure the inputs are in [-1, 1] range as opposed to [0, 1].**_
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_b8_fe/1.md
+++ b/assets/docs/sayakpaul/vit_b8_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/vit_b8_fe/1
+
+Vision Transformer feature extractor fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/B_8-i21k-300ep-lr_0.001-aug_medium2-wd_0.1-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.01-res_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type B-8 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_b8_fe/1", trainable=True)
+])
+...
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_l16_classification/1.md
+++ b/assets/docs/sayakpaul/vit_l16_classification/1.md
@@ -1,0 +1,49 @@
+# Module sayakpaul/vit_l16_classification/1
+
+Vision Transformer (ViT) fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/L_16-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.1-sd_0.1--imagenet2012-steps_20k-lr_0.01-res_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/classification.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type L-16 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_l16_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+The model also has a [feature extractor variant](https://tfhub.dev/sayakpaul/vit_l16_fe/1) which should be used for the purposes of transfer learning. For more details, please refer to the accompanying Colab Notebook. _**Please make sure the inputs are in [-1, 1] range as opposed to [0, 1].**_
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_l16_fe/1.md
+++ b/assets/docs/sayakpaul/vit_l16_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/vit_l16_fe/1
+
+Vision Transformer feature extractor fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/L_16-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.1-sd_0.1--imagenet2012-steps_20k-lr_0.01-res_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type L-16 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_l16_fe/1", trainable=True)
+])
+...
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_r26_s32_lightaug_classification/1.md
+++ b/assets/docs/sayakpaul/vit_r26_s32_lightaug_classification/1.md
@@ -1,0 +1,49 @@
+# Module sayakpaul/vit_r26_s32_lightaug_classification/1
+
+Hybrid Vision Transformer (ViT) fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/R26_S_32-i21k-300ep-lr_0.001-aug_light0-wd_0.03-do_0.1-sd_0.1--imagenet2012-steps_20k-lr_0.03-res_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/classification.ipynb -->
+
+
+## Overview
+
+This model is a hybrid Vision Transformer of type R26-S32 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_r26_s32_lightaug_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+The model also has a [feature extractor variant](https://tfhub.dev/sayakpaul/vit_r26_s32_lightaug_fe/1) which should be used for the purposes of transfer learning. For more details, please refer to the accompanying Colab Notebook. _**Please make sure the inputs are in [-1, 1] range as opposed to [0, 1].**_
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_r26_s32_lightaug_fe/1.md
+++ b/assets/docs/sayakpaul/vit_r26_s32_lightaug_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/vit_r26_s32_lightaug_fe/1
+
+Vision Transformer feature extractor fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/R26_S_32-i21k-300ep-lr_0.001-aug_medium2-wd_0.1-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.01-res_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb -->
+
+
+## Overview
+
+This model is a hybrid Vision Transformer of type R26-S32 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_r26_s32_lightaug_fe/1", trainable=True)
+])
+...
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_r26_s32_medaug_classification/1.md
+++ b/assets/docs/sayakpaul/vit_r26_s32_medaug_classification/1.md
@@ -1,0 +1,49 @@
+# Module sayakpaul/vit_r26_s32_medaug_classification/1
+
+Hybrid Vision Transformer (ViT) fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/R26_S_32-i21k-300ep-lr_0.001-aug_medium2-wd_0.1-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.01-res_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/classification.ipynb -->
+
+
+## Overview
+
+This model is a hybrid Vision Transformer of type R26-S32 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_r26_s32_medaug_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+The model also has a [feature extractor variant](https://tfhub.dev/sayakpaul/vit_r26_s32_medaug_fe/1) which should be used for the purposes of transfer learning. For more details, please refer to the accompanying Colab Notebook. _**Please make sure the inputs are in [-1, 1] range as opposed to [0, 1].**_
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_r26_s32_medaug_fe/1.md
+++ b/assets/docs/sayakpaul/vit_r26_s32_medaug_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/vit_r26_s32_medaug_fe/1
+
+Vision Transformer feature extractor fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/R26_S_32-i21k-300ep-lr_0.001-aug_medium2-wd_0.1-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.01-res_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb -->
+
+
+## Overview
+
+This model is a hybrid Vision Transformer of type R26-S32 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_r26_s32_medaug_fe/1", trainable=True)
+])
+...
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_r50_l32_classification/1.md
+++ b/assets/docs/sayakpaul/vit_r50_l32_classification/1.md
@@ -1,0 +1,49 @@
+# Module sayakpaul/vit_r50_l32_classification/1
+
+Hybrid Vision Transformer (ViT) fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/R50_L_32-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.1-sd_0.1--imagenet2012-steps_20k-lr_0.01-res_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/classification.ipynb -->
+
+
+## Overview
+
+This model is a hybrid Vision Transformer of type R50-L32 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_r50_l32_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+The model also has a [feature extractor variant](https://tfhub.dev/sayakpaul/vit_r50_l32_fe/1) which should be used for the purposes of transfer learning. For more details, please refer to the accompanying Colab Notebook. _**Please make sure the inputs are in [-1, 1] range as opposed to [0, 1].**_
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_r50_l32_fe/1.md
+++ b/assets/docs/sayakpaul/vit_r50_l32_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/vit_r50_l32_fe/1
+
+Vision Transformer feature extractor fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/R50_L_32-i21k-300ep-lr_0.001-aug_medium1-wd_0.1-do_0.1-sd_0.1--imagenet2012-steps_20k-lr_0.01-res_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb -->
+
+
+## Overview
+
+This model is a hybrid Vision Transformer of type R50-L32 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_r50_l32_fe/1", trainable=True)
+])
+...
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_s16_classification/1.md
+++ b/assets/docs/sayakpaul/vit_s16_classification/1.md
@@ -1,0 +1,49 @@
+# Module sayakpaul/vit_s16_classification/1
+
+Vision Transformer (ViT) fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/S_16-i21k-300ep-lr_0.001-aug_light1-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/classification.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type S-16 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_s16_classification/1")
+])
+predictions = model.predict(images) 
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+The model also has a [feature extractor variant](https://tfhub.dev/sayakpaul/vit_s16_fe/1) which should be used for the purposes of transfer learning. For more details, please refer to the accompanying Colab Notebook. _**Please make sure the inputs are in [-1, 1] range as opposed to [0, 1].**_
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/assets/docs/sayakpaul/vit_s16_fe/1.md
+++ b/assets/docs/sayakpaul/vit_s16_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/vit_s16_fe/1
+
+Vision Transformer feature extractor fine-tuned on ImageNet-1k.
+
+<!-- asset-path: https://storage.googleapis.com/flowers-experimental/S_16-i21k-300ep-lr_0.001-aug_light1-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: vit -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb -->
+
+
+## Overview
+
+This model is a Vision Transformer of type S-16 [1, 2] fine-tuned on the ImageNet-1k dataset [3]. 
+
+## Using this model
+
+```python
+model = tf.keras.Sequential([
+    hub.KerasLayer("https://tfhub.dev/sayakpaul/vit_s16_fe/1", trainable=True)
+])
+...
+```
+
+Inputs to the model must:
+
+1. be four dimensional Tensors of the shape `(batch_size, height, width, num_channels)`. Note that the model expects images with  `channels_last`  property. `num_channels` must be 3. 
+2. be resized to 224x224 resolution.
+3. have pixel values in the range `[-1, 1]`.
+
+
+## Notes
+
+The original model weights are provided as a `.npz` file [4]. There were ported to a TensorFlow SavedModel. The porting steps are available in [5].
+
+## References
+
+[1] [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale by Dosovitskiy et al.](https://arxiv.org/abs/2010.11929) 
+
+[2] [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers by Steiner et al.](https://arxiv.org/abs/2106.10270)
+
+[3] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)  
+
+[4] [Vision Transformer GitHub](https://github.com/google-research/vision_transformer)
+
+[5] [Colab Notebook for assembling ViT models in TensorFlow](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/conversion.ipynb)

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -209,3 +209,5 @@ values:
     display_name: Big Transfer
   - id: swin-transformer
     display_name: Swin Transformer
+  - id: vit
+    display_name: Vision Transformer


### PR DESCRIPTION
@MorganR @WGierke FYI

The [fine-tuning notebook](https://colab.research.google.com/github/sayakpaul/ViT-jax2tf/blob/main/fine_tune.ipynb) linked in this collection closely follows the [official notebook](https://colab.research.google.com/github/google-research/vision_transformer/blob/linen/vit_jax.ipynb) for training recipes like data augmentation, LR scheduling, optimizer hyperparameters, and so on. 