### PR TITLE
Add `smaller_LaBSE_15lang` model and my publisher profile

### DIFF
--- a/assets/docs/jeongukjae/jeongukjae.md
+++ b/assets/docs/jeongukjae/jeongukjae.md
@@ -1,0 +1,11 @@
+# Publisher jeongukjae
+Ukjae Jeong
+
+[![Icon URL]](https://github.com/jeongukjae.png)
+
+## Ukjae Jeong
+
+Machine Learning Engineer.
+
+**GitHub:** [jeongukjae](https://github.com/jeongukjae)\
+**LinkedIn:** [jeongukjae](https://www.linkedin.com/in/jeongukjae/)

--- a/assets/docs/jeongukjae/jeongukjae.md
+++ b/assets/docs/jeongukjae/jeongukjae.md
@@ -8,4 +8,5 @@ Ukjae Jeong
 Machine Learning Engineer.
 
 **GitHub:** [jeongukjae](https://github.com/jeongukjae)\
-**LinkedIn:** [jeongukjae](https://www.linkedin.com/in/jeongukjae/)
+**LinkedIn:** [jeongukjae](https://www.linkedin.com/in/jeongukjae/)\
+**Personal Website:** [jeongukjae.github.io](https://jeongukjae.github.io)

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
@@ -1,0 +1,90 @@
+# Module jeongukjae/smaller_LaBSE_15lang/1
+
+Patched [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) model using "Load What You Need: Smaller Multilingual Transformers" method to reduce word embedding parameters.
+
+<!-- asset-path: https://github.com/jeongukjae/smaller-labse/releases/download/15lang-1/smaller_LaBSE_15lang.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: ar -->
+<!-- language: zh-cn -->
+<!-- language: en -->
+<!-- language: fr -->
+<!-- language: de -->
+<!-- language: it -->
+<!-- language: ja -->
+<!-- language: ko -->
+<!-- language: nl -->
+<!-- language: pl -->
+<!-- language: pt -->
+<!-- language: es -->
+<!-- language: th -->
+<!-- language: tr -->
+<!-- language: ru -->
+
+## Overview
+
+The smaller LaBSE(language-agnostic BERT sentence embedding) is a patched version of [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) to handle fewer languages by applying ["Load What You Need: Smaller Versions of Multilingual BERT"](https://arxiv.org/abs/2010.05609). To summarize the contents of the paper, only selected tokens that appear frequently in the corpus(Wikipedia dump for this model) are left in the word embedding table.
+
+Since this model is not subsequently trained, and the only thing changed is relocating vectors in the word embedding table, this model will encode texts in the exact same way as [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) if texts are preprocessed in the same way. (it means, if all tokens you want to encode is selected, the representations won't change)
+
+You can check the code at [this repository (jeongukjae/smaller-labse)](https://github.com/jeongukjae/smaller-labse)
+
+## Model Size
+
+| Model                             | #param(transformer) | #param(word embedding) | #param(model) | vocab size |
+| --------------------------------- | ------------------: | ---------------------: | ------------: | ---------: |
+| google/LaBSE/2                    |               85.1M |                 384.9M |        470.9M |    501,153 |
+| jeongukjae/smaller_LaBSE_15lang/1 |               85.1M |                 133.1M |        219.2M |    173,347 |
+
+## Example Use
+
+```python
+import tensorflow as tf
+import tensorflow_text  # noqa
+import tensorflow_hub as hub
+
+# Loading models from tfhub.dev
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/smaller_LaBSE_15lang/1")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/smaller_LaBSE_15lang_preprocess/1")
+
+# Constructing model to encode texts into high-dimensional vectors
+sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
+encoder_inputs = preprocessor(sentences)
+sentence_representation = encoder(encoder_inputs)["pooled_output"]
+normalized_sentence_representation = tf.nn.l2_normalize(sentence_representation, axis=-1)  # for cosine similarity
+model = tf.keras.Model(sentences, normalized_sentence_representation)
+model.summary()
+
+# Encoding multilingual sentences.
+english_sentences = tf.constant(["dog", "Puppies are nice.", "I enjoy taking long walks along the beach with my dog."])
+italian_sentences = tf.constant(["cane", "I cuccioli sono carini.", "Mi piace fare lunghe passeggiate lungo la spiaggia con il mio cane."])
+japanese_sentences = tf.constant(["犬", "子犬はいいです", "私は犬と一緒にビーチを散歩するのが好きです"])
+
+english_embeds = model(english_sentences)
+italian_embeds = model(italian_sentences)
+japanese_embeds = model(japanese_sentences)
+
+# English-Italian similarity
+print(tf.tensordot(english_embeds, italian_embeds, axes=[[1], [1]]))
+
+# English-Japanese similarity
+print(tf.tensordot(english_embeds, japanese_embeds, axes=[[1], [1]]))
+
+# Italian-Japanese similarity
+print(tf.tensordot(italian_embeds, japanese_embeds, axes=[[1], [1]]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+* `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representaiton.
+* `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
+* `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+
+## References
+
+* [Language-agnostic BERT Sentence Embedding](https://arxiv.org/abs/2007.01852)
+* [Load What You Need: Smaller Versions of Multilingual BERT](https://arxiv.org/abs/2010.05609).

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
@@ -2,7 +2,7 @@
 
 Patched [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) model using "Load What You Need: Smaller Multilingual Transformers" method to reduce word embedding parameters.
 
-<!-- asset-path: https://github.com/jeongukjae/smaller-labse/releases/download/15lang-1/smaller_LaBSE_15lang.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/smaller-LaBSE/smaller_LaBSE_15lang.tar.gz -->
 <!-- network-architecture: transformer -->
 <!-- task: text-embedding -->
 <!-- fine-tunable: true -->

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
@@ -27,9 +27,9 @@ Patched [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) model using "Load Wha
 
 The smaller LaBSE(language-agnostic BERT sentence embedding) is a patched version of [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) to handle fewer languages by applying ["Load What You Need: Smaller Versions of Multilingual BERT"](https://arxiv.org/abs/2010.05609). To summarize the contents of the paper, only selected tokens that appear frequently in the corpus(Wikipedia dump for this model) are left in the word embedding table.
 
-Since this model is not subsequently trained, and the only thing changed is relocating vectors in the word embedding table, this model will encode texts in the exact same way as [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) if texts are preprocessed in the same way. (it means, if all tokens you want to encode is selected, the representations won't change)
+Since this model is not subsequently trained, and the only thing changed is relocating vectors in the word embedding table, this model will encode texts in the exact same way as [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) if texts are preprocessed in the same way(it means, if all tokens you want to encode is selected, the representations won't change).
 
-You can check the code at [this repository (jeongukjae/smaller-labse)](https://github.com/jeongukjae/smaller-labse)
+You can check the code at [this repository (jeongukjae/smaller-labse)](https://github.com/jeongukjae/smaller-labse).
 
 ## Model Size
 

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
@@ -80,7 +80,7 @@ print(tf.tensordot(italian_embeds, japanese_embeds, axes=[[1], [1]]))
 
 The outputs of this model are a dict, and each entries are as follows:
 
-* `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representaiton.
+* `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
 * `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
 * `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
 

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
@@ -1,0 +1,64 @@
+# Module jeongukjae/smaller_LaBSE_15lang_preprocess/1
+
+Text preprocessing model for `jeongukjae/smaller_LaBSE_15lang/1`.
+
+<!-- asset-path: https://github.com/jeongukjae/smaller-labse/releases/download/15lang-1/smaller_LaBSE_15lang_preprocess.tar.gz -->
+<!-- task: text-preprocessing -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+
+## Overview
+
+This model is patched version of `google/universal-sentence-encoder-cmlm/multilingual-preprocess/2` to use with `jeongukjae/smaller_LaBSE_15lang/1`. This model is constructed by selecting tokens that appear frequently in Wikipedia dump data.
+
+## Prerequisites
+
+This model uses [`BertTokenizer`](https://www.tensorflow.org/text/api_docs/python/text/BertTokenizer) in TensorFlow Text. You can register required ops as follows.
+
+```python
+# Install it with "pip install tensorflow-text"
+import tensorflow_text as text
+```
+
+## Usage
+
+This model is exported using [`official/nlp/tools/export_tfhub_lib.py::export_preprocessing`](https://github.com/tensorflow/models/blob/v2.6.0/official/nlp/tools/export_tfhub_lib.py#L392) in [tf-models-official==2.6.0](https://github.com/tensorflow/models/blob/v2.6.0/), so usage is very similar to the text preprocessing models for BERT in tfhub (for example, [tensorflow/bert_en_cased_preprocess/3](https://tfhub.dev/tensorflow/bert_en_cased_preprocess/3)).
+
+### Preprocess single text segment
+
+```python
+sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/smaller_LaBSE_15lang_preprocess/1")
+model_inputs = preprocessor(sentences)
+```
+
+### Preprocess multiple text segments
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/smaller_LaBSE_15lang_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+# You can use different sequence length like below. (default is 128)
+#
+# bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs, arguments=dict(seq_length=seq_length))
+
+sentences = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_a"),
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_a"),
+]
+tokenized_sentences = [tokenize(segment) for segment in sentences]
+model_inputs = bert_pack_inputs(tokenized_sentences)
+```
+
+### Output details
+
+The result of preprocessing is a batch of fixed-length input sequences for the Transformer encoder.
+
+An input sequence starts with one start-of-sequence token, followed by the tokenized segments, each terminated by one end-of-segment token. Remaining positions up to `seq_length`, if any, are filled up with padding tokens. If an input sequence would exceed `seq_length`, the tokenized segments in it are truncated to prefixes of approximately equal sizes to fit exactly.
+
+The `encoder_inputs` are a dict of three int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of
+input sequences as follows:
+
+* `"input_word_ids"`: has the token ids of the input sequences.
+* `"input_mask"`: has value 1 at the position of all input tokens present before padding and value 0 for the padding tokens.
+* `"input_type_ids"`: has the index of the input segment that gave rise to the input token at the respective position. The first input segment (index 0) includes the start-of-sequence token and its end-of-segment token. The second segment (index 1, if present) includes its end-of-segment token. Padding tokens get index 0 again.

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
@@ -73,8 +73,7 @@ The result of preprocessing is a batch of fixed-length input sequences for the T
 
 An input sequence starts with one start-of-sequence token, followed by the tokenized segments, each terminated by one end-of-segment token. Remaining positions up to `seq_length`, if any, are filled up with padding tokens. If an input sequence would exceed `seq_length`, the tokenized segments in it are truncated to prefixes of approximately equal sizes to fit exactly.
 
-The `encoder_inputs` are a dict of three int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of
-input sequences as follows:
+The `encoder_inputs` are a dict of three int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of input sequences as follows:
 
 * `"input_word_ids"`: has the token ids of the input sequences.
 * `"input_mask"`: has value 1 at the position of all input tokens present before padding and value 0 for the padding tokens.

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
@@ -1,15 +1,32 @@
 # Module jeongukjae/smaller_LaBSE_15lang_preprocess/1
 
-Text preprocessing model for `jeongukjae/smaller_LaBSE_15lang/1`.
+Text preprocessing model for [`jeongukjae/smaller_LaBSE_15lang/1`](https://tfhub.dev/jeongukjae/smaller_LaBSE_15lang/1).
 
 <!-- asset-path: https://github.com/jeongukjae/smaller-labse/releases/download/15lang-1/smaller_LaBSE_15lang_preprocess.tar.gz -->
 <!-- task: text-preprocessing -->
+<!-- dataset: wikipedia -->
+<!-- dataset: commoncrawl -->
 <!-- fine-tunable: false -->
 <!-- format: saved_model_2 -->
+<!-- language: ar -->
+<!-- language: zh-cn -->
+<!-- language: en -->
+<!-- language: fr -->
+<!-- language: de -->
+<!-- language: it -->
+<!-- language: ja -->
+<!-- language: ko -->
+<!-- language: nl -->
+<!-- language: pl -->
+<!-- language: pt -->
+<!-- language: es -->
+<!-- language: th -->
+<!-- language: tr -->
+<!-- language: ru -->
 
 ## Overview
 
-This model is patched version of `google/universal-sentence-encoder-cmlm/multilingual-preprocess/2` to use with `jeongukjae/smaller_LaBSE_15lang/1`. This model is constructed by selecting tokens that appear frequently in Wikipedia dump data.
+This model is patched version of [`google/universal-sentence-encoder-cmlm/multilingual-preprocess/2`](https://tfhub.dev/google/universal-sentence-encoder-cmlm/multilingual-preprocess/2) to use with [`jeongukjae/smaller_LaBSE_15lang/1`](https://tfhub.dev/jeongukjae/smaller_LaBSE_15lang/1). This model is constructed by selecting tokens that appear frequently in Wikipedia dump data.
 
 ## Prerequisites
 

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
@@ -2,7 +2,7 @@
 
 Text preprocessing model for [`jeongukjae/smaller_LaBSE_15lang/1`](https://tfhub.dev/jeongukjae/smaller_LaBSE_15lang/1).
 
-<!-- asset-path: https://github.com/jeongukjae/smaller-labse/releases/download/15lang-1/smaller_LaBSE_15lang_preprocess.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/smaller-LaBSE/smaller_LaBSE_15lang_preprocess.tar.gz -->
 <!-- task: text-preprocessing -->
 <!-- dataset: wikipedia -->
 <!-- dataset: commoncrawl -->


### PR DESCRIPTION
- Add my publisher profile
- Add `jeongukjae/smaller_LaBSE_15lang` and `jeongukjae/smaller_LaBSE_15lang_preprocess` models

This model is a smaller version of LaBSE for handling fewer languages to reduce parameter size. (471M -> 219M)

Relative TensorFlow Forum Post: https://discuss.tensorflow.org/t/reducing-the-parameter-size-of-labse-language-agnostic-bert-sentence-embedding-for-practical-usage

---

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

Please provide only one commit. You can continuously add changes to your latest commit using [`git commit --amend`](https://stackoverflow.com/q/179123) followed by `git push -f` to update your remote branch. Alternatively, [here](https://stackoverflow.com/q/5189560) are details on how to squash multiple commits into one commit.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.