### PR TITLE
Remove links from summaries of smaller_LaBSE models

### DIFF
--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang/1.md
@@ -1,6 +1,6 @@
 # Module jeongukjae/smaller_LaBSE_15lang/1
 
-Patched [google/LaBSE/2](https://tfhub.dev/google/LaBSE/2) model using "Load What You Need: Smaller Multilingual Transformers" method to reduce word embedding parameters.
+Patched `google/LaBSE/2` model using "Load What You Need: Smaller Multilingual Transformers" method to reduce word embedding parameters.
 
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/smaller-LaBSE/smaller_LaBSE_15lang.tar.gz -->
 <!-- network-architecture: transformer -->

--- a/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/smaller_LaBSE_15lang_preprocess/1.md
@@ -1,6 +1,6 @@
 # Module jeongukjae/smaller_LaBSE_15lang_preprocess/1
 
-Text preprocessing model for [`jeongukjae/smaller_LaBSE_15lang/1`](https://tfhub.dev/jeongukjae/smaller_LaBSE_15lang/1).
+Text preprocessing model for `jeongukjae/smaller_LaBSE_15lang/1`.
 
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/smaller-LaBSE/smaller_LaBSE_15lang_preprocess.tar.gz -->
 <!-- task: text-preprocessing -->


### PR DESCRIPTION
Remove links from summaries since links aren't rendered there.