### PR TITLE
Add DistilBERT models

### DIFF
--- a/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
@@ -5,6 +5,7 @@ A small, fast, cheap and light Transformer model trained by distilling BERT base
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-cased.tar.gz -->
 <!-- network-architecture: transformer -->
 <!-- task: text-embedding -->
+<!-- license: apache-2.0 -->
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
 <!-- language: en -->

--- a/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
@@ -80,7 +80,7 @@ The outputs of this model are a dict, and each entries are as follows:
 
 - `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
 - `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
-- `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+- `"encoder_outputs"`: A list of 6 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
 
 ## References
 

--- a/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
@@ -1,4 +1,4 @@
-# Module jeongukjae/distilbert_en_cased_L-6_H-768_A-12
+# Module jeongukjae/distilbert_en_cased_L-6_H-768_A-12/1
 
 A small, fast, cheap and light Transformer model trained by distilling BERT base cased model.
 
@@ -45,7 +45,7 @@ sentences = tf.constant(["(your text here)"])
 print(embedding_model(sentences))
 ```
 
-### Build model for mutli text inputs
+### Build model for multi text inputs
 
 If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
 

--- a/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
@@ -12,7 +12,7 @@ A small, fast, cheap and light Transformer model trained by distilling BERT base
 
 ## Overview
 
-This model is the almost same model as [`distilbert-base-cased`](https://huggingface.co/distilbert-base-cased) in HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-cased).
+This model is a tensorflow conversion of [`distilbert-base-cased`](https://huggingface.co/distilbert-base-cased) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-cased).
 
 ## Model Size
 

--- a/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_cased_L-6_H-768_A-12/1.md
@@ -1,0 +1,87 @@
+# Module jeongukjae/distilbert_en_cased_L-6_H-768_A-12
+
+A small, fast, cheap and light Transformer model trained by distilling BERT base cased model.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-cased.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: en -->
+
+## Overview
+
+This model is the almost same model as [`distilbert-base-cased`](https://huggingface.co/distilbert-base-cased) in HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-cased).
+
+## Model Size
+
+| Model                              | Total # params |
+| ---------------------------------- | -------------: |
+| bert_en_cased_L-12_H-768_A-12      |           108M |
+| distilbert_en_cased_L-6_H-768_A-12 |            65M |
+
+## Example Use
+
+You can use this model with an interface that is almost identical to bert's in tfhub.
+
+For example, you can define a text embedding model with below code.
+
+```python
+# define a text embedding model
+text_input = tf.keras.layers.Input(shape=(), dtype=tf.string)
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_en_cased_preprocess/1")
+encoder_inputs = preprocessor(text_input)
+
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_en_cased_L-6_H-768_A-12/1", trainable=True)
+encoder_outputs = encoder(encoder_inputs)
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(encoder_inputs, pooled_output)
+
+# You can embed your sentences as follows
+sentences = tf.constant(["(your text here)"])
+print(embedding_model(sentences))
+```
+
+### Build model for mutli text inputs
+
+If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilbert_en_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_en_cased_L-6_H-768_A-12/1", trainable=True)
+
+text_inputs = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+]
+tokenized_inputs = [tokenize(segment) for segment in text_inputs]
+encoder_inputs = bert_pack_inputs(tokenized_inputs)
+encoder_outputs = encoder(encoder_inputs)
+
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(encoder_inputs, pooled_output)
+
+# You can pass your sentences as follows
+hypotheses = tf.constant(["(your hypothesis text here)"])
+premises = tf.constant(["(your premise text here)"])
+print(embedding_model([hypotheses, premises]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+- `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
+- `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
+- `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+
+## References
+
+- [DistilBERT, a distilled version of BERT: smaller, faster, cheaper and lighter](https://arxiv.org/abs/1910.01108)
+- [`distilbert-base-cased` Model card in HuggingFace model hub](https://huggingface.co/distilbert-base-cased)

--- a/assets/docs/jeongukjae/models/distilbert_en_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_cased_preprocess/1.md
@@ -5,6 +5,7 @@ Text preprocessing model for `jeongukjae/distilbert_en_cased_L-6_H-768_A-12/1`.
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-cased-preprocess.tar.gz -->
 <!-- task: text-preprocessing -->
 <!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
 <!-- format: saved_model_2 -->
 <!-- language: en -->
 

--- a/assets/docs/jeongukjae/models/distilbert_en_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_cased_preprocess/1.md
@@ -1,0 +1,65 @@
+# Module jeongukjae/distilbert_en_cased_preprocess
+
+Text preprocessing model for `jeongukjae/distilbert_en_cased_L-6_H-768_A-12/1`.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-cased-preprocess.tar.gz -->
+<!-- task: text-preprocessing -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+<!-- language: en -->
+
+## Overview
+
+This model is a text preprocessing model for [`jeongukjae/distilbert_en_cased_L-6_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilbert_en_cased_L-6_H-768_A-12/1). This model uses same vocab file with [tensorflow/bert_en_cased_preprocess/3](https://tfhub.dev/tensorflow/bert_en_cased_preprocess/3) and has almost same feature, but does not return token type ids, since distilBERT does not use token type ids.
+
+This model has no trainable parameters and can be used in an input pipeline outside the training loop.
+
+## Prerequisites
+
+This model uses [`BertTokenizer`](https://www.tensorflow.org/text/api_docs/python/text/BertTokenizer) in TensorFlow Text. You can register required ops as follows.
+
+```python
+# Install it with "pip install tensorflow-text"
+import tensorflow_text as text
+```
+
+## Usage
+
+This model supports preprocessing single or multi segment text inputs.
+
+### Preprocess single text segment
+
+```python
+sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_en_cased_preprocess/1")
+encoder_inputs = preprocessor(sentences)
+```
+
+### Preprocess multiple text segments
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilbert_en_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+# You can use different sequence length like below. (default is 128)
+#
+# bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs, arguments=dict(seq_length=64))
+
+sentences = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_a"),
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_b"),
+]
+tokenized_sentences = [tokenize(segment) for segment in sentences]
+encoder_inputs = bert_pack_inputs(tokenized_sentences)
+```
+
+### Output details
+
+The result of preprocessing is a batch of fixed-length input sequences for the DistilBERT encoder.
+
+An input sequence starts with one start-of-sequence token, followed by the tokenized segments, each terminated by one end-of-segment token. Remaining positions up to `seq_length`, if any, are filled up with padding tokens. If an input sequence would exceed `seq_length`, the tokenized segments in it are truncated to prefixes of approximately equal sizes to fit exactly.
+
+The `encoder_inputs` are a dict of two int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of input sequences as follows:
+
+* `"input_word_ids"`: has the token ids of the input sequences.
+* `"input_mask"`: has value 1 at the position of all input tokens present before padding and value 0 for the padding tokens.

--- a/assets/docs/jeongukjae/models/distilbert_en_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_cased_preprocess/1.md
@@ -1,4 +1,4 @@
-# Module jeongukjae/distilbert_en_cased_preprocess
+# Module jeongukjae/distilbert_en_cased_preprocess/1
 
 Text preprocessing model for `jeongukjae/distilbert_en_cased_L-6_H-768_A-12/1`.
 

--- a/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
@@ -1,4 +1,4 @@
-# Module jeongukjae/distilbert_en_uncased_L-6_H-768_A-12
+# Module jeongukjae/distilbert_en_uncased_L-6_H-768_A-12/1
 
 A small, fast, cheap and light Transformer model trained by distilling BERT base uncased model.
 
@@ -45,7 +45,7 @@ sentences = tf.constant(["(your text here)"])
 print(embedding_model(sentences))
 ```
 
-### Build model for mutli text inputs
+### Build model for multi text inputs
 
 If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
 

--- a/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
@@ -80,7 +80,7 @@ The outputs of this model are a dict, and each entries are as follows:
 
 * `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
 * `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
-* `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+* `"encoder_outputs"`: A list of 6 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
 
 ## References
 

--- a/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
@@ -12,7 +12,7 @@ A small, fast, cheap and light Transformer model trained by distilling BERT base
 
 ## Overview
 
-This model is the almost same model as [`distilbert-base-uncased`](https://huggingface.co/distilbert-base-uncased) in HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-uncased).
+This model is a tensorflow conversion of [`distilbert-base-uncased`](https://huggingface.co/distilbert-base-uncased) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-uncased).
 
 ## Model Size
 

--- a/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
@@ -1,0 +1,87 @@
+# Module jeongukjae/distilbert_en_uncased_L-6_H-768_A-12
+
+A small, fast, cheap and light Transformer model trained by distilling BERT base uncased model.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-uncased.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: en -->
+
+## Overview
+
+This model is the almost same model as [`distilbert-base-uncased`](https://huggingface.co/distilbert-base-uncased) in HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-uncased).
+
+## Model Size
+
+| Model                                | Total # params |
+| ------------------------------------ | -------------: |
+| bert_en_uncased_L-12_H-768_A-12      |           109M |
+| distilbert_en_uncased_L-6_H-768_A-12 |            66M |
+
+## Example Use
+
+You can use this model with an interface that is almost identical to bert's in tfhub.
+
+For example, you can define a text embedding model with below code.
+
+```python
+# define a text embedding model
+text_input = tf.keras.layers.Input(shape=(), dtype=tf.string)
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_en_uncased_preprocess/1")
+encoder_inputs = preprocessor(text_input)
+
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_en_uncased_L-6_H-768_A-12/1", trainable=True)
+encoder_outputs = encoder(encoder_inputs)
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(encoder_inputs, pooled_output)
+
+# You can embed your sentences as follows
+sentences = tf.constant(["(your text here)"])
+print(embedding_model(sentences))
+```
+
+### Build model for mutli text inputs
+
+If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilbert_en_uncased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_en_uncased_L-6_H-768_A-12/1", trainable=True)
+
+text_inputs = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+]
+tokenized_inputs = [tokenize(segment) for segment in text_inputs]
+encoder_inputs = bert_pack_inputs(tokenized_inputs)
+encoder_outputs = encoder(encoder_inputs)
+
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(encoder_inputs, pooled_output)
+
+# You can pass your sentences as follows
+hypotheses = tf.constant(["(your hypothesis text here)"])
+premises = tf.constant(["(your premise text here)"])
+print(embedding_model([hypotheses, premises]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+* `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
+* `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
+* `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+
+## References
+
+* [DistilBERT, a distilled version of BERT: smaller, faster, cheaper and lighter](https://arxiv.org/abs/1910.01108)
+* [`distilbert-base-uncased` Model card in HuggingFace model hub](https://huggingface.co/distilbert-base-uncased)

--- a/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_uncased_L-6_H-768_A-12/1.md
@@ -6,6 +6,7 @@ A small, fast, cheap and light Transformer model trained by distilling BERT base
 <!-- network-architecture: transformer -->
 <!-- task: text-embedding -->
 <!-- fine-tunable: true -->
+<!-- license: apache-2.0 -->
 <!-- format: saved_model_2 -->
 <!-- language: en -->
 

--- a/assets/docs/jeongukjae/models/distilbert_en_uncased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_uncased_preprocess/1.md
@@ -5,6 +5,7 @@ Text preprocessing model for `jeongukjae/distilbert_en_uncased_L-6_H-768_A-12/1`
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-uncased-preprocess.tar.gz -->
 <!-- task: text-preprocessing -->
 <!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
 <!-- format: saved_model_2 -->
 <!-- language: en -->
 

--- a/assets/docs/jeongukjae/models/distilbert_en_uncased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_uncased_preprocess/1.md
@@ -1,0 +1,65 @@
+# Module jeongukjae/distilbert_en_uncased_preprocess
+
+Text preprocessing model for `jeongukjae/distilbert_en_uncased_L-6_H-768_A-12/1`.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-uncased-preprocess.tar.gz -->
+<!-- task: text-preprocessing -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+<!-- language: en -->
+
+## Overview
+
+This model is a text preprocessing model for [`jeongukjae/distilbert_en_uncased_L-6_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilbert_en_uncased_L-6_H-768_A-12/1). This model uses same vocab file with [tensorflow/bert_en_uncased_preprocess/3](https://tfhub.dev/tensorflow/bert_en_uncased_preprocess/3) and has almost same feature, but does not return token type ids, since distilBERT does not use token type ids.
+
+This model has no trainable parameters and can be used in an input pipeline outside the training loop.
+
+## Prerequisites
+
+This model uses [`BertTokenizer`](https://www.tensorflow.org/text/api_docs/python/text/BertTokenizer) in TensorFlow Text. You can register required ops as follows.
+
+```python
+# Install it with "pip install tensorflow-text"
+import tensorflow_text as text
+```
+
+## Usage
+
+This model supports preprocessing single or multi segment text inputs.
+
+### Preprocess single text segment
+
+```python
+sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_en_uncased_preprocess/1")
+encoder_inputs = preprocessor(sentences)
+```
+
+### Preprocess multiple text segments
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilbert_en_uncased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+# You can use different sequence length like below. (default is 128)
+#
+# bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs, arguments=dict(seq_length=64))
+
+sentences = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_a"),
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_b"),
+]
+tokenized_sentences = [tokenize(segment) for segment in sentences]
+encoder_inputs = bert_pack_inputs(tokenized_sentences)
+```
+
+### Output details
+
+The result of preprocessing is a batch of fixed-length input sequences for the DistilBERT encoder.
+
+An input sequence starts with one start-of-sequence token, followed by the tokenized segments, each terminated by one end-of-segment token. Remaining positions up to `seq_length`, if any, are filled up with padding tokens. If an input sequence would exceed `seq_length`, the tokenized segments in it are truncated to prefixes of approximately equal sizes to fit exactly.
+
+The `encoder_inputs` are a dict of two int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of input sequences as follows:
+
+* `"input_word_ids"`: has the token ids of the input sequences.
+* `"input_mask"`: has value 1 at the position of all input tokens present before padding and value 0 for the padding tokens.

--- a/assets/docs/jeongukjae/models/distilbert_en_uncased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_en_uncased_preprocess/1.md
@@ -1,4 +1,4 @@
-# Module jeongukjae/distilbert_en_uncased_preprocess
+# Module jeongukjae/distilbert_en_uncased_preprocess/1
 
 Text preprocessing model for `jeongukjae/distilbert_en_uncased_L-6_H-768_A-12/1`.
 

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
@@ -8,6 +8,38 @@ A small, fast, cheap and light Transformer model trained by distilling multiling
 <!-- license: apache-2.0 -->
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
+<!-- language: ar -->
+<!-- language: bn -->
+<!-- language: bg -->
+<!-- language: ca -->
+<!-- language: zh-cn -->
+<!-- language: zh-tw -->
+<!-- language: da -->
+<!-- language: en -->
+<!-- language: et -->
+<!-- language: fi -->
+<!-- language: fr -->
+<!-- language: de -->
+<!-- language: el -->
+<!-- language: he -->
+<!-- language: hi -->
+<!-- language: id -->
+<!-- language: it -->
+<!-- language: ja -->
+<!-- language: ko -->
+<!-- language: nl -->
+<!-- language: no -->
+<!-- language: pl -->
+<!-- language: pt -->
+<!-- language: ro -->
+<!-- language: ru -->
+<!-- language: es -->
+<!-- language: sv -->
+<!-- language: ta -->
+<!-- language: tr -->
+<!-- language: uk -->
+<!-- language: ur -->
+<!-- language: vi -->
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
@@ -11,7 +11,7 @@ A small, fast, cheap and light Transformer model trained by distilling BERT base
 
 ## Overview
 
-This model is a tensorflow conversion of [`distilbert-base-multilingual-cased`](https://huggingface.co/distilbert-base-multilingual-cased) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-cased).
+This model is a tensorflow conversion of [`distilbert-base-multilingual-cased`](https://huggingface.co/distilbert-base-multilingual-cased) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-multilingual-cased).
 
 ## Model Size
 
@@ -79,7 +79,7 @@ The outputs of this model are a dict, and each entries are as follows:
 
 - `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
 - `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
-- `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+- `"encoder_outputs"`: A list of 6 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
 
 ## References
 

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
@@ -1,6 +1,6 @@
-# Module jeongukjae/distilbert_mutli_cased_L-6_H-768_A-12
+# Module jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1
 
-A small, fast, cheap and light Transformer model trained by distilling BERT base cased model.
+A small, fast, cheap and light Transformer model trained by distilling multilingual BERT base cased model.
 
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-multilingual-cased.tar.gz -->
 <!-- network-architecture: transformer -->
@@ -44,7 +44,7 @@ sentences = tf.constant(["(your text here)"])
 print(embedding_model(sentences))
 ```
 
-### Build model for mutli text inputs
+### Build model for multi text inputs
 
 If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
 

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
@@ -11,7 +11,7 @@ A small, fast, cheap and light Transformer model trained by distilling BERT base
 
 ## Overview
 
-This model is the almost same model as [`distilbert-base-multilingual-cased`](https://huggingface.co/distilbert-base-multilingual-cased) in HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-cased).
+This model is a tensorflow conversion of [`distilbert-base-multilingual-cased`](https://huggingface.co/distilbert-base-multilingual-cased) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-cased).
 
 ## Model Size
 

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
@@ -5,6 +5,7 @@ A small, fast, cheap and light Transformer model trained by distilling BERT base
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-multilingual-cased.tar.gz -->
 <!-- network-architecture: transformer -->
 <!-- task: text-embedding -->
+<!-- license: apache-2.0 -->
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
 

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_L-6_H-768_A-12/1.md
@@ -1,0 +1,86 @@
+# Module jeongukjae/distilbert_mutli_cased_L-6_H-768_A-12
+
+A small, fast, cheap and light Transformer model trained by distilling BERT base cased model.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-multilingual-cased.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+
+## Overview
+
+This model is the almost same model as [`distilbert-base-multilingual-cased`](https://huggingface.co/distilbert-base-multilingual-cased) in HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/distilbert-base-cased).
+
+## Model Size
+
+| Model                                 | Total # params |
+| ------------------------------------- | -------------: |
+| bert_multi_cased_L-12_H-768_A-12      |           178M |
+| distilbert_multi_cased_L-6_H-768_A-12 |           135M |
+
+## Example Use
+
+You can use this model with an interface that is almost identical to bert's in tfhub.
+
+For example, you can define a text embedding model with below code.
+
+```python
+# define a text embedding model
+text_input = tf.keras.layers.Input(shape=(), dtype=tf.string)
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_multi_cased_preprocess/1")
+encoder_inputs = preprocessor(text_input)
+
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1", trainable=True)
+encoder_outputs = encoder(encoder_inputs)
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(encoder_inputs, pooled_output)
+
+# You can embed your sentences as follows
+sentences = tf.constant(["(your text here)"])
+print(embedding_model(sentences))
+```
+
+### Build model for mutli text inputs
+
+If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilbert_multi_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1", trainable=True)
+
+text_inputs = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+]
+tokenized_inputs = [tokenize(segment) for segment in text_inputs]
+encoder_inputs = bert_pack_inputs(tokenized_inputs)
+encoder_outputs = encoder(encoder_inputs)
+
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(encoder_inputs, pooled_output)
+
+# You can pass your sentences as follows
+hypotheses = tf.constant(["(your hypothesis text here)"])
+premises = tf.constant(["(your premise text here)"])
+print(embedding_model([hypotheses, premises]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+- `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
+- `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
+- `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+
+## References
+
+- [DistilBERT, a distilled version of BERT: smaller, faster, cheaper and lighter](https://arxiv.org/abs/1910.01108)
+- [`distilbert-base-multilingual-cased` Model card in HuggingFace model hub](https://huggingface.co/distilbert-base-multilingual-cased)

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_preprocess/1.md
@@ -1,0 +1,64 @@
+# Module jeongukjae/distilbert_multi_cased_preprocess
+
+Text preprocessing model for `jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1`.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-cased-preprocess.tar.gz -->
+<!-- task: text-preprocessing -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+
+## Overview
+
+This model is a text preprocessing model for [`jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1). This model uses same vocab file with [tensorflow/bert_multi_cased_preprocess/3](https://tfhub.dev/tensorflow/bert_multi_cased_preprocess/3) and has almost same feature, but does not return token type ids, since distilBERT does not use token type ids.
+
+This model has no trainable parameters and can be used in an input pipeline outside the training loop.
+
+## Prerequisites
+
+This model uses [`BertTokenizer`](https://www.tensorflow.org/text/api_docs/python/text/BertTokenizer) in TensorFlow Text. You can register required ops as follows.
+
+```python
+# Install it with "pip install tensorflow-text"
+import tensorflow_text as text
+```
+
+## Usage
+
+This model supports preprocessing single or multi segment text inputs.
+
+### Preprocess single text segment
+
+```python
+sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilbert_multi_cased_preprocess/1")
+encoder_inputs = preprocessor(sentences)
+```
+
+### Preprocess multiple text segments
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilbert_multi_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+# You can use different sequence length like below. (default is 128)
+#
+# bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs, arguments=dict(seq_length=64))
+
+sentences = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_a"),
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_b"),
+]
+tokenized_sentences = [tokenize(segment) for segment in sentences]
+encoder_inputs = bert_pack_inputs(tokenized_sentences)
+```
+
+### Output details
+
+The result of preprocessing is a batch of fixed-length input sequences for the DistilBERT encoder.
+
+An input sequence starts with one start-of-sequence token, followed by the tokenized segments, each terminated by one end-of-segment token. Remaining positions up to `seq_length`, if any, are filled up with padding tokens. If an input sequence would exceed `seq_length`, the tokenized segments in it are truncated to prefixes of approximately equal sizes to fit exactly.
+
+The `encoder_inputs` are a dict of two int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of input sequences as follows:
+
+* `"input_word_ids"`: has the token ids of the input sequences.
+* `"input_mask"`: has value 1 at the position of all input tokens present before padding and value 0 for the padding tokens.

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_preprocess/1.md
@@ -7,6 +7,38 @@ Text preprocessing model for `jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1
 <!-- fine-tunable: false -->
 <!-- license: apache-2.0 -->
 <!-- format: saved_model_2 -->
+<!-- language: ar -->
+<!-- language: bn -->
+<!-- language: bg -->
+<!-- language: ca -->
+<!-- language: zh-cn -->
+<!-- language: zh-tw -->
+<!-- language: da -->
+<!-- language: en -->
+<!-- language: et -->
+<!-- language: fi -->
+<!-- language: fr -->
+<!-- language: de -->
+<!-- language: el -->
+<!-- language: he -->
+<!-- language: hi -->
+<!-- language: id -->
+<!-- language: it -->
+<!-- language: ja -->
+<!-- language: ko -->
+<!-- language: nl -->
+<!-- language: no -->
+<!-- language: pl -->
+<!-- language: pt -->
+<!-- language: ro -->
+<!-- language: ru -->
+<!-- language: es -->
+<!-- language: sv -->
+<!-- language: ta -->
+<!-- language: tr -->
+<!-- language: uk -->
+<!-- language: ur -->
+<!-- language: vi -->
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_preprocess/1.md
@@ -5,6 +5,7 @@ Text preprocessing model for `jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilbert/distilbert-base-cased-preprocess.tar.gz -->
 <!-- task: text-preprocessing -->
 <!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
 <!-- format: saved_model_2 -->
 
 ## Overview

--- a/assets/docs/jeongukjae/models/distilbert_multi_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilbert_multi_cased_preprocess/1.md
@@ -1,4 +1,4 @@
-# Module jeongukjae/distilbert_multi_cased_preprocess
+# Module jeongukjae/distilbert_multi_cased_preprocess/1
 
 Text preprocessing model for `jeongukjae/distilbert_multi_cased_L-6_H-768_A-12/1`.
 


### PR DESCRIPTION
Hi, there.

I converted DistilBERT models(en-cased, en-uncased, multi-cased) in huggingface model hub to TF SavedModel format, and want to upload these models to tfhub.dev. I checked whether this models are converted appropriately as follows.

* Checked all exported encoders returning very close logits for random inputs (https://github.com/jeongukjae/huggingface-to-tfhub/blob/77b019c27adb340ab872b623f149e5fc9bf1a074/convert_bert.py#L143)
* Fine-tune this models with some GLUE dataset. (https://colab.research.google.com/drive/1jkTrAYWTWKKIpUHfWFiYfzLii87myqL2?usp=sharing)

---

Repository containing converting scripts: https://github.com/jeongukjae/huggingface-to-tfhub