### PR TITLE
Fix a minor formatting error in ConvMixer Collection

### DIFF
--- a/assets/docs/rishit-dagli/collections/convmixer/1.md
+++ b/assets/docs/rishit-dagli/collections/convmixer/1.md
@@ -29,7 +29,11 @@ Reported accuracies are measured on ImageNet-1k validation dataset.
 ## References
 
 [1] [ConvMixer-torch2tf](https://github.com/Rishit-dagli/ConvMixer-torch2tf)
+
 [2] Official Code Implementation: https://github.com/tmp-iclr/convmixer
+
 [3] Anonymous. Patches Are All You Need? 2021. openreview.net, https://openreview.net/forum?id=TVHS5Y4dNvM.
+
 [4] [ImageNet-1k](https://www.image-net.org/challenges/LSVRC/2012/index.php)
+
 [5] [onnx-tensorflow](https://github.com/onnx/onnx-tensorflow)


### PR DESCRIPTION
I noticed today that the collection I made in #92 had a formatting error in the References section, all of the references were displayed in a single line. This is a small PR to fix that.

---

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
