### PR TITLE
Add sentence encoder model for Korean (`distilkobert_sentence_encoder`)

### DIFF
--- a/assets/docs/jeongukjae/models/distilkobert_cased_L-3_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_cased_L-3_H-768_A-12/1.md
@@ -1,13 +1,13 @@
 # Module jeongukjae/distilkobert_cased_L-3_H-768_A-12/1
 
+Distillation of KoBERT from SKTBrain (Lightweight KoBERT).
+
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilkobert/distilkobert_cased_L-3_H-768_A-12.tar.gz -->
 <!-- network-architecture: transformer -->
 <!-- task: text-embedding -->
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
-
-Distillation of KoBERT from SKTBrain (Lightweight KoBERT).
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/distilkobert_cased_L-3_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_cased_L-3_H-768_A-12/1.md
@@ -1,0 +1,75 @@
+# Module jeongukjae/distilkobert_cased_L-3_H-768_A-12/1
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilkobert/distilkobert_cased_L-3_H-768_A-12.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+Distillation of KoBERT from SKTBrain (Lightweight KoBERT).
+
+## Overview
+
+This model is a tensorflow conversion of [`monologg/DistilKoBERT`](https://github.com/monologg/DistilKoBERT). It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the README file in the original repository](https://github.com/monologg/DistilKoBERT/blob/master/README.md).
+
+## Example Use
+
+You can use this model with an interface that is almost identical to bert's in tfhub.
+
+For example, you can define a text embedding model with below code.
+
+```python
+# define a text embedding model
+text_input = tf.keras.layers.Input(shape=(), dtype=tf.string)
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilkobert_cased_preprocess/1")
+encoder_inputs = preprocessor(text_input)
+
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/1", trainable=True)
+encoder_outputs = encoder(encoder_inputs)
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(text_inputs, pooled_output)
+
+# You can embed your sentences as follows
+sentences = tf.constant(["(your text here)"])
+print(model(sentences))
+```
+
+### Build model for multi text inputs
+
+If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilkobert_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/1", trainable=True)
+
+text_inputs = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+]
+tokenized_inputs = [tokenize(segment) for segment in text_inputs]
+encoder_inputs = bert_pack_inputs(tokenized_inputs)
+encoder_outputs = encoder(encoder_inputs)
+
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(text_inputs, pooled_output)
+
+# You can pass your sentences as follows
+hypotheses = tf.constant(["(your hypothesis text here)"])
+premises = tf.constant(["(your premise text here)"])
+print(model([hypotheses, premises]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+- `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
+- `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
+- `"encoder_outputs"`: A list of 3 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.

--- a/assets/docs/jeongukjae/models/distilkobert_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_cased_preprocess/1.md
@@ -1,0 +1,65 @@
+# Module jeongukjae/distilkobert_cased_preprocess/1
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilkobert/distilkobert_cased_preprocess.tar.gz -->
+<!-- task: text-preprocessing -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+Text preprocessing model for `jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`.
+
+## Overview
+
+This model is a text preprocessing model for [`jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/1). This model does not return token type ids, since distilBERT does not use token type ids.
+
+This model has no trainable parameters and can be used in an input pipeline outside the training loop.
+
+## Prerequisites
+
+This model uses [`SentencepieceTokenizer`](https://www.tensorflow.org/text/api_docs/python/text/SentencepieceTokenizer) in TensorFlow Text. You can register required ops as follows.
+
+```python
+# Install it with "pip install tensorflow-text"
+import tensorflow_text as text
+```
+
+## Usage
+
+This model supports preprocessing single or multi segment text inputs.
+
+### Preprocess single text segment
+
+```python
+sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/2")
+encoder_inputs = preprocessor(sentences)
+```
+
+### Preprocess multiple text segments
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/2")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+# You can use different sequence length like below. (default is 128)
+#
+# bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs, arguments=dict(seq_length=64))
+
+sentences = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_a"),
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_b"),
+]
+tokenized_sentences = [tokenize(segment) for segment in sentences]
+encoder_inputs = bert_pack_inputs(tokenized_sentences)
+```
+
+### Output details
+
+The result of preprocessing is a batch of fixed-length input sequences for the DistilBERT encoder.
+
+An input sequence starts with one start-of-sequence token, followed by the tokenized segments, each terminated by one end-of-segment token. Remaining positions up to `seq_length`, if any, are filled up with padding tokens. If an input sequence would exceed `seq_length`, the tokenized segments in it are truncated to prefixes of approximately equal sizes to fit exactly.
+
+The `encoder_inputs` are a dict of two int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of input sequences as follows:
+
+* `"input_word_ids"`: has the token ids of the input sequences.
+* `"input_mask"`: has value 1 at the position of all input tokens present before padding and value 0 for the padding tokens.

--- a/assets/docs/jeongukjae/models/distilkobert_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_cased_preprocess/1.md
@@ -1,12 +1,12 @@
 # Module jeongukjae/distilkobert_cased_preprocess/1
 
+Text preprocessing model for `jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`.
+
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilkobert/distilkobert_cased_preprocess.tar.gz -->
 <!-- task: text-preprocessing -->
 <!-- fine-tunable: false -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
-
-Text preprocessing model for `jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`.
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/distilkobert_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_cased_preprocess/1.md
@@ -31,14 +31,14 @@ This model supports preprocessing single or multi segment text inputs.
 
 ```python
 sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
-preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/2")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilkobert_cased_preprocess/1")
 encoder_inputs = preprocessor(sentences)
 ```
 
 ### Preprocess multiple text segments
 
 ```python
-preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/2")
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/distilkobert_cased_preprocess/1")
 tokenize = hub.KerasLayer(preprocessor.tokenize)
 bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
 # You can use different sequence length like below. (default is 128)

--- a/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
@@ -11,7 +11,7 @@ Korean sentence encoder model using `jeongukjae/distilkobert_cased_L-3_H-768_A-1
 
 ## Overview
 
-This model is a fine-tuned sentence encoder model using [`jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/1), KorSTS and KLUE STS datasets. You can simply extract Korean sentence embeddings with this model.
+This model is a fine-tuned sentence encoder model based on [`jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/1) using KorSTS and KLUE STS datasets. I applied knowledge distillation to train this model. You can simply extract Korean sentence embeddings with this model efficiently.
 
 ## Model Performance
 

--- a/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
@@ -1,0 +1,108 @@
+# Module jeongukjae/distilkobert_sentence_encoder/1
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilkobert/distilkobert_sentence_encoder_cased_L-3_H-768_A-12.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+Korean sentence encoder model using `jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`.
+
+## Overview
+
+This model is a fine-tuned sentence encoder model using [`jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/1), KorSTS and KLUE STS datasets. You can simply extract Korean sentence embeddings with this model.
+
+## Model Performance
+
+### KorSTS development set
+
+|Model|# Params|encoding strategy|Spearman correlation * 100|
+|---|--:|---|--:|
+|**distilkobert_sentence_encoder**|28M|bi-encoding|86.53|
+|Korean SRoBERTa (base)†|111M|bi-encoding|83.54|
+|Korean SRoBERTa (large)†|338M|bi-encoding|84.21|
+|SXLM-R (base)†|270M|bi-encoding|81.95|
+|SXLM-R (large)†|550M|bi-encoding|84.13|
+|Korean RoBERTa (base)†|111M|cross-encoding|84.97|
+|Korean RoBERTa (large)†|338M|cross-encoding|87.82|
+|XLM-R (base)†|270M|cross-encoding|83.02|
+|XLM-R (large)†|550M|cross-encoding|88.37|
+
+* †: results from [Ham et al., 2020](https://arxiv.org/abs/2004.03289).
+
+### KorSTS test set
+
+|Model|# Params|encoding strategy|Spearman correlation * 100|
+|---|--:|---|--:|
+|**distilkobert_sentence_encoder**|28M|bi-encoding|83.12|
+|Korean SRoBERTa (base)†|111M|bi-encoding|80.29|
+|Korean SRoBERTa (large)†|338M|bi-encoding|80.49|
+|SXLM-R (base)†|270M|bi-encoding|79.13|
+|SXLM-R (large)†|550M|bi-encoding|81.84|
+|Korean RoBERTa (base)†|111M|cross-encoding|83.00|
+|Korean RoBERTa (large)†|338M|cross-encoding|85.27|
+|XLM-R (base)†|270M|cross-encoding|77.78|
+|XLM-R (large)†|550M|cross-encoding|84.68|
+
+* †: results from [Ham et al., 2020](https://arxiv.org/abs/2004.03289).
+
+### KLUE STS development set
+
+|Model|# Params|encoding strategy|Pearson correlation * 100|
+|---|--:|---|--:|
+|**distilkobert_sentence_encoder**|28M|bi-encoding|86.87|
+|KLUE-BERT (base)*|110M|cross-encoding|91.01|
+|KLUE-RoBERTa (base)*|110M|cross-encoding|92.91|
+
+* \*: results from [Park et al., 2021](https://arxiv.org/abs/2105.09680)
+
+## Example Use
+
+```python
+# Load required models
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilkobert_sentence_encoder/1")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/distilkobert_cased_preprocess/1")
+
+# Define sentence encoder model
+inputs = tf.keras.Input([], dtype=tf.string)
+encoder_inputs = preprocessor(inputs)
+sentence_embedding = encoder(encoder_inputs)
+normalized_sentence_embedding = tf.nn.l2_normalize(sentence_embedding, axis=-1)
+model = tf.keras.Model(inputs, normalized_sentence_embedding)
+
+# Encode sentences using distilkobert_sentence_encoder
+sentences1 = tf.constant([
+    "다만, 도로와 인접해서 거리의 소음이 들려요.",
+    "형이 다시 캐나다 들어가야 하니 가족모임 일정은 바꾸지 마세요.",
+    "방안에 필요한 시설이 모두 있어서 매우 편리합니다.",
+    "관광자원화 검토를 모범적으로 적용한 지자체에는 홍보·컨설팅, 관광상품 개발 지원 등을 제공할 계획이다.",
+])
+sentences2 = tf.constant([
+    "하지만, 길과 가깝기 때문에 거리의 소음을 들을 수 있습니다.",
+    "가족 모임 일정은 바꾸지 말도록 하십시오.",
+    "특히, 숙소 근처에 안전한 실내 주차장이 있어서 편리합니다.",
+    "아울러 지자체, 지역관광협회 등과 함께 수시로 관광지 현장을 점검할 계획이다.",
+])
+embeddings1 = model(sentences1)
+embeddings2 = model(sentences2)
+
+# Calculate cosine similarity
+print(tf.tensordot(embeddings1, embeddings2, axes=[[1], [1]]))
+# Expected outputs:
+#
+# tf.Tensor(
+# [[ 0.8907616   0.07906969 -0.09612353  0.00167902]
+#  [ 0.0184274   0.6840409  -0.1102942   0.02653065]
+#  [-0.00795126 -0.10688838  0.5041443  -0.01270578]
+#  [ 0.04684553 -0.0619101   0.00684686  0.68705124]], shape=(4, 4), dtype=float32)
+```
+
+## Output details
+
+The output of this model is a tensor of shape `[batch size, hidden size(768 for this model)]`
+
+## References
+
+* [KorNLI and KorSTS: New Benchmark Datasets for Korean Natural Language Understanding](https://arxiv.org/abs/2004.03289)
+* [KLUE: Korean Language Understanding Evaluation](https://arxiv.org/abs/2105.09680)

--- a/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
@@ -1,13 +1,13 @@
 # Module jeongukjae/distilkobert_sentence_encoder/1
 
+Korean sentence encoder model using `jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`.
+
 <!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilkobert/distilkobert_sentence_encoder_cased_L-3_H-768_A-12.tar.gz -->
 <!-- network-architecture: transformer -->
 <!-- task: text-embedding -->
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
-
-Korean sentence encoder model using `jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`.
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
@@ -2,7 +2,7 @@
 
 Korean sentence encoder model using `jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`.
 
-<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilkobert/distilkobert_sentence_encoder_cased_L-3_H-768_A-12.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/distilkobert/distilkobert_sentence_encoder.tar.gz -->
 <!-- network-architecture: transformer -->
 <!-- task: text-embedding -->
 <!-- fine-tunable: true -->

--- a/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
@@ -11,7 +11,7 @@ Korean sentence encoder model using `jeongukjae/distilkobert_cased_L-3_H-768_A-1
 
 ## Overview
 
-This model is a fine-tuned sentence encoder model based on [`jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/1) using KorSTS and KLUE STS datasets. I applied knowledge distillation to train this model. You can simply extract Korean sentence embeddings with this model efficiently.
+This model is a fine-tuned sentence encoder model based on [`jeongukjae/distilkobert_cased_L-3_H-768_A-12/1`](https://tfhub.dev/jeongukjae/distilkobert_cased_L-3_H-768_A-12/1) using KorSTS and KLUE STS datasets. I applied knowledge distillation to train this model. You can simply extract Korean sentence embeddings efficiently with this model.
 
 ## Model Performance
 


### PR DESCRIPTION
Hi, I want to add my sentence encoder model along with the base model([distilkobert](https://github.com/monologg/DistilKoBERT)) that I used for training.

* Add distilkobert and preprocessing model
* Add distilkobert sentence encoder model.

---

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.