### PR TITLE
Update tables in `jeongukjae/distilkobert_sentence_encoder/1`

### DIFF
--- a/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
@@ -18,7 +18,7 @@ This model is a fine-tuned sentence encoder model based on [`jeongukjae/distilko
 ### KorSTS development set
 
 |Model|# Params|encoding strategy|Spearman correlation * 100|
-|---|--:|---|--:|
+|---|---:|---|---:|
 |**distilkobert_sentence_encoder**|28M|bi-encoding|86.53|
 |Korean SRoBERTa (base)†|111M|bi-encoding|83.54|
 |Korean SRoBERTa (large)†|338M|bi-encoding|84.21|
@@ -34,7 +34,7 @@ This model is a fine-tuned sentence encoder model based on [`jeongukjae/distilko
 ### KorSTS test set
 
 |Model|# Params|encoding strategy|Spearman correlation * 100|
-|---|--:|---|--:|
+|---|---:|---|---:|
 |**distilkobert_sentence_encoder**|28M|bi-encoding|83.12|
 |Korean SRoBERTa (base)†|111M|bi-encoding|80.29|
 |Korean SRoBERTa (large)†|338M|bi-encoding|80.49|
@@ -50,7 +50,7 @@ This model is a fine-tuned sentence encoder model based on [`jeongukjae/distilko
 ### KLUE STS development set
 
 |Model|# Params|encoding strategy|Pearson correlation * 100|
-|---|--:|---|--:|
+|---|---:|---|---:|
 |**distilkobert_sentence_encoder**|28M|bi-encoding|86.87|
 |KLUE-BERT (base)*|110M|cross-encoding|91.01|
 |KLUE-RoBERTa (base)*|110M|cross-encoding|92.91|

--- a/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
+++ b/assets/docs/jeongukjae/models/distilkobert_sentence_encoder/1.md
@@ -17,45 +17,45 @@ This model is a fine-tuned sentence encoder model based on [`jeongukjae/distilko
 
 ### KorSTS development set
 
-|Model|# Params|encoding strategy|Spearman correlation * 100|
-|---|---:|---|---:|
-|**distilkobert_sentence_encoder**|28M|bi-encoding|86.53|
-|Korean SRoBERTa (base)†|111M|bi-encoding|83.54|
-|Korean SRoBERTa (large)†|338M|bi-encoding|84.21|
-|SXLM-R (base)†|270M|bi-encoding|81.95|
-|SXLM-R (large)†|550M|bi-encoding|84.13|
-|Korean RoBERTa (base)†|111M|cross-encoding|84.97|
-|Korean RoBERTa (large)†|338M|cross-encoding|87.82|
-|XLM-R (base)†|270M|cross-encoding|83.02|
-|XLM-R (large)†|550M|cross-encoding|88.37|
+| Model                             | # Params | encoding strategy | Spearman correlation \* 100 |
+| --------------------------------- | -------: | ----------------- | --------------------------: |
+| **distilkobert_sentence_encoder** |      28M | bi-encoding       |                       86.53 |
+| Korean SRoBERTa (base)†           |     111M | bi-encoding       |                       83.54 |
+| Korean SRoBERTa (large)†          |     338M | bi-encoding       |                       84.21 |
+| SXLM-R (base)†                    |     270M | bi-encoding       |                       81.95 |
+| SXLM-R (large)†                   |     550M | bi-encoding       |                       84.13 |
+| Korean RoBERTa (base)†            |     111M | cross-encoding    |                       84.97 |
+| Korean RoBERTa (large)†           |     338M | cross-encoding    |                       87.82 |
+| XLM-R (base)†                     |     270M | cross-encoding    |                       83.02 |
+| XLM-R (large)†                    |     550M | cross-encoding    |                       88.37 |
 
-* †: results from [Ham et al., 2020](https://arxiv.org/abs/2004.03289).
+- †: results from [Ham et al., 2020](https://arxiv.org/abs/2004.03289).
 
 ### KorSTS test set
 
-|Model|# Params|encoding strategy|Spearman correlation * 100|
-|---|---:|---|---:|
-|**distilkobert_sentence_encoder**|28M|bi-encoding|83.12|
-|Korean SRoBERTa (base)†|111M|bi-encoding|80.29|
-|Korean SRoBERTa (large)†|338M|bi-encoding|80.49|
-|SXLM-R (base)†|270M|bi-encoding|79.13|
-|SXLM-R (large)†|550M|bi-encoding|81.84|
-|Korean RoBERTa (base)†|111M|cross-encoding|83.00|
-|Korean RoBERTa (large)†|338M|cross-encoding|85.27|
-|XLM-R (base)†|270M|cross-encoding|77.78|
-|XLM-R (large)†|550M|cross-encoding|84.68|
+| Model                             | # Params | encoding strategy | Spearman correlation \* 100 |
+| --------------------------------- | -------: | ----------------- | --------------------------: |
+| **distilkobert_sentence_encoder** |      28M | bi-encoding       |                       83.12 |
+| Korean SRoBERTa (base)†           |     111M | bi-encoding       |                       80.29 |
+| Korean SRoBERTa (large)†          |     338M | bi-encoding       |                       80.49 |
+| SXLM-R (base)†                    |     270M | bi-encoding       |                       79.13 |
+| SXLM-R (large)†                   |     550M | bi-encoding       |                       81.84 |
+| Korean RoBERTa (base)†            |     111M | cross-encoding    |                       83.00 |
+| Korean RoBERTa (large)†           |     338M | cross-encoding    |                       85.27 |
+| XLM-R (base)†                     |     270M | cross-encoding    |                       77.78 |
+| XLM-R (large)†                    |     550M | cross-encoding    |                       84.68 |
 
-* †: results from [Ham et al., 2020](https://arxiv.org/abs/2004.03289).
+- †: results from [Ham et al., 2020](https://arxiv.org/abs/2004.03289).
 
 ### KLUE STS development set
 
-|Model|# Params|encoding strategy|Pearson correlation * 100|
-|---|---:|---|---:|
-|**distilkobert_sentence_encoder**|28M|bi-encoding|86.87|
-|KLUE-BERT (base)*|110M|cross-encoding|91.01|
-|KLUE-RoBERTa (base)*|110M|cross-encoding|92.91|
+| Model                             | # Params | encoding strategy | Pearson correlation \* 100 |
+| --------------------------------- | -------: | ----------------- | -------------------------: |
+| **distilkobert_sentence_encoder** |      28M | bi-encoding       |                      86.87 |
+| KLUE-BERT (base)\*                |     110M | cross-encoding    |                      91.01 |
+| KLUE-RoBERTa (base)\*             |     110M | cross-encoding    |                      92.91 |
 
-* \*: results from [Park et al., 2021](https://arxiv.org/abs/2105.09680)
+- \*: results from [Park et al., 2021](https://arxiv.org/abs/2105.09680)
 
 ## Example Use
 
@@ -104,5 +104,5 @@ The output of this model is a tensor of shape `[batch size, hidden size(768 for 
 
 ## References
 
-* [KorNLI and KorSTS: New Benchmark Datasets for Korean Natural Language Understanding](https://arxiv.org/abs/2004.03289)
-* [KLUE: Korean Language Understanding Evaluation](https://arxiv.org/abs/2105.09680)
+- [KorNLI and KorSTS: New Benchmark Datasets for Korean Natural Language Understanding](https://arxiv.org/abs/2004.03289)
+- [KLUE: Korean Language Understanding Evaluation](https://arxiv.org/abs/2105.09680)


### PR DESCRIPTION
Hi, I saw the tables in [this model page(jeongukjae/distilkobert_sentence_encoder/1)](https://tfhub.dev/jeongukjae/distilkobert_sentence_encoder/1) isn't rendered properly. So I'm sending this pull request to fix it. (I didn't changed any content, just changing the format)

---

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
