### PR TITLE
Add TNT s model

### DIFF
--- a/assets/docs/rishit-dagli/tnt-s/1.md
+++ b/assets/docs/rishit-dagli/tnt-s/1.md
@@ -49,9 +49,13 @@ Make sure to download the class names first:
 Here is a complete example to infer on an image:
 
 ```py
-import tensorflow_hub as hub
-import tensorflow as tf
+from io import BytesIO
+
 import numpy as np
+import requests
+import tensorflow as tf
+import tensorflow_hub as hub
+from PIL import image
 
 model = hub.load("https://tfhub.dev/rishit-dagli/tnt-s/1")
 
@@ -100,7 +104,7 @@ infer_on_image(
 ### Notes
 
 - The original model weights are provided as a PyTorch model [2]. They were ported to a TensorFlow SavedModel.
-- The model inputs should be four dimensional Tensors of the shape (batch_size, height, width, num_channels)` in the range `[-1, 1]`.
+- The model input should be a four dimensional Tensor of the shape (batch_size, height, width, num_channels)` in the range `[-1, 1]`.
 - My TensorFlow implemntation of TNT could be found at [3].
 
 ### References

--- a/assets/docs/rishit-dagli/tnt-s/1.md
+++ b/assets/docs/rishit-dagli/tnt-s/1.md
@@ -1,0 +1,111 @@
+# Module rishit-dagli/tnt-s/1
+
+The Transformer iN Transformer (TNT) model uses pixel level attention paired with patch level attention for image classification.
+
+<!-- task: image-classification -->
+<!-- network-architecture: tnt -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/rishit-dagli.appspot.com/tnt_s_patch16_224.tar.gz -->
+<!-- colab: https://colab.research.google.com/github/Rishit-dagli/ConvMixer-torch2tf/blob/main/classification.ipynb -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+
+The TNT model was proposed in the paper "Transformer in Transformer" by Han et al. for image classification pre-trained on ImageNet-1K. TNT S with (just) 23.8 M parameters and 5.2 GFLOPS achieves 81.4% top-1 accuracy and 95.7% top-5 accuracy on ImageNet-1K.
+
+### Example use
+
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/tnt-s/1")
+```
+
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the TensorFlow preffered channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+It can also be used within a KerasLayer:
+
+```py
+import tensorflow_hub as hub
+
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/tnt-s/1")
+```
+
+### A complete example
+
+Make sure to download the class names first:
+
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
+
+Here is a complete example to infer on an image:
+
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+
+model = hub.load("https://tfhub.dev/rishit-dagli/tnt-s/1")
+
+
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (resolution[0], resolution[1]))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized = (image_resized - 127.5) / 127.5
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.5, 0.5, 0.5), variance=(0.25, 0.25, 0.25)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
+
+
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
+
+
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+def infer_on_image(img_url, expected_label, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    assert (
+        predicted_label == expected_label
+    ), f"Expected {expected_label} but was {predicted_label}"
+
+
+infer_on_image(
+    img_url="https://i.imgur.com/NFsafX4.jpg", expected_label="tench, Tinca_tinca"
+)
+infer_on_image(
+    img_url="https://i.imgur.com/Wv99De3.jpg", expected_label="window_screen"
+)
+```
+
+### Notes
+
+- The original model weights are provided as a PyTorch model [2]. They were ported to a TensorFlow SavedModel.
+- The model inputs should be four dimensional Tensors of the shape (batch_size, height, width, num_channels)` in the range `[-1, 1]`.
+- My TensorFlow implemntation of TNT could be found at [3].
+
+### References
+
+[1] Han, Kai, et al. ‘Transformer in Transformer’. ArXiv:2103.00112 [Cs], Oct. 2021. arXiv.org, http://arxiv.org/abs/2103.00112.
+[2] [Official PyTorch implementation](https://github.com/huawei-noah/CV-Backbones/tree/master/tnt_pytorch)
+[3] [My TensorFlow implementation](https://github.com/Rishit-dagli/Transformer-in-Transformer)
+[4] [An unofficial PyTorch implementation](https://github.com/lucidrains/transformer-in-transformer)

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -219,3 +219,5 @@ values:
     display_name: NNCLR
   - id: convmixer
     display_name: ConvMixer
+  - id: tnt
+    display_name: Transformer iN Transformer


### PR DESCRIPTION
This PR adds the Transformer iN Transformer (TNT) model that uses pixel level attention paired with patch level attention for image classification. The TNT model was proposed in the paper "Transformer in Transformer" by Han et al. for image classification pre-trained on ImageNet-1K. TNT S with (just) 23.8 M parameters and 5.2 GFLOPS achieves 81.4% top-1 accuracy and 95.7% top-5 accuracy on ImageNet-1K.

The original NeurIPS 2021 paper can be found [here](https://proceedings.neurips.cc//paper/2021/hash/854d9fca60b4bd07f9bb215d59ef5561-Abstract.html) 

---

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
