### PR TITLE
Add TridentNet models

### DIFF
--- a/assets/docs/rishit-dagli/rishit-dagli.md
+++ b/assets/docs/rishit-dagli/rishit-dagli.md
@@ -5,8 +5,8 @@ Rishit Dagli.
 
 ## Details
 Rishit Dagli ([@rishit_dagli](https://twitter.com/rishit_dagli)).
-10 th Grade Student.
-TedX, TedEd Speaker.
+High School Student.
+TEDx, TEDEd Speaker.
 
 **GitHub:** [Rishit-dagli](https://github.com/Rishit-dagli)\
 **Personal Website:** [rishit.tech](https://www.rishit.tech)\

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-lite/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-lite/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/tridentnet-cppe5-lite/1
+The TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TF Lite Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: tridentnet -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-lite/default/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/tridentnet-cppe5-lite/default/1
+TF Lite version of the TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/tridentnet-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/lite/model.tflite -->
+
+### Overview
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Li, Yanghao, et al. ‘Scale-Aware Trident Networks for Object Detection’. ArXiv:1901.01892 [Cs], Aug. 2019. arXiv.org, http://arxiv.org/abs/1901.01892.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-lite/fp16/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/tridentnet-cppe5-lite/fp16/1
+TF Lite quantized version of the TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/tridentnet-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/lite/model_f16.tflite -->
+
+### Overview
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Li, Yanghao, et al. ‘Scale-Aware Trident Networks for Object Detection’. ArXiv:1901.01892 [Cs], Aug. 2019. arXiv.org, http://arxiv.org/abs/1901.01892.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/1.md
@@ -1,4 +1,4 @@
-# Placeholder rishit-dagli/faster-rcnn-cppe5-tfjs/1
+# Placeholder rishit-dagli/tridentnet-cppe5-tfjs/1
 The TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TFJS Format.
 
 <!-- task: image-object-detection -->

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/faster-rcnn-cppe5-tfjs/1
+The TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TFJS Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: tridentnet -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/default/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/tridentnet-cppe5-tfjs/default/1
+TFJS version of the TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/tridentnet-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tfjs/tridentnet_tfjs.tar.gz -->
+
+### Overview
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/tridentnet-cppe5/default/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Li, Yanghao, et al. ‘Scale-Aware Trident Networks for Object Detection’. ArXiv:1901.01892 [Cs], Aug. 2019. arXiv.org, http://arxiv.org/abs/1901.01892.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/fp16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/tridentnet-cppe5-tfjs/fp16/1
+TFJS FP16 quantized version of the TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/tridentnet-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tfjs/tridentnet_fp16.tar.gz -->
+
+### Overview
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/tridentnet-cppe5-tfjs/fp16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `float16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Li, Yanghao, et al. ‘Scale-Aware Trident Networks for Object Detection’. ArXiv:1901.01892 [Cs], Aug. 2019. arXiv.org, http://arxiv.org/abs/1901.01892.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/uint16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/tridentnet-cppe5-tfjs/uint16/1
+TFJS uint16 quantized version of the TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/tridentnet-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tfjs/tridentnet_uint8.tar.gz -->
+
+### Overview
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/tridentnet-cppe5-tfjs/uint16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Li, Yanghao, et al. ‘Scale-Aware Trident Networks for Object Detection’. ArXiv:1901.01892 [Cs], Aug. 2019. arXiv.org, http://arxiv.org/abs/1901.01892.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/uint8/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/tridentnet-cppe5-tfjs/uint8/1
+TFJS uint8 quantized version of the TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/tridentnet-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tfjs/tridentnet_uint8.tar.gz -->
+
+### Overview
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/tridentnet-cppe5-tfjs/uint8/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint8` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Li, Yanghao, et al. ‘Scale-Aware Trident Networks for Object Detection’. ArXiv:1901.01892 [Cs], Aug. 2019. arXiv.org, http://arxiv.org/abs/1901.01892.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/tridentnet-cppe5/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5/1.md
@@ -1,0 +1,72 @@
+# Module rishit-dagli/tridentnet-cppe5/1
+
+The TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: faster-r-cnn -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tf_tridentnet.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Model Performance
+Here we present the performance of the TridentNet model on the CPPE - 5 dataset. For evaluation, we adopt the metrics from the COCO detection evaluation criteria, including the mean Average Precision (AP) across IoU thresholds ranging from 0.50 to 0.95 at different scales.
+
+|   Method    | AP<sup>box</sup> | AP<sub>50</sub><sup>box</sup> | AP<sub>75</sub><sup>box</sup> | AP<sub>S</sub><sup>box</sup> | AP<sub>M</sub><sup>box</sup> | AP<sub>L</sub><sup>box</sup> |
+| :---------: | :--------------: | :---------------------------: | :---------------------------: | :--------------------------: | :--------------------------: | :--------------------------: |
+| TridentNet | 52.9 | 85.1 | 58.3 | 42.6 | 41.3 | 62.6 |
+
+### Usage
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/tridentnet-cppe5/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['dets']`: A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- `outputs['labels']`: A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+It can also be used within a KerasLayer:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/tridentnet-cppe5/1")
+```
+
+### Model Complexity
+We measure the model complexity in terms of the number of parameters FLOPS and FPS. The inference speed FPS (Frames per second) for detector is measured on a machine with 1 Tesla V100 GPU.
+
+|          Method           |      AP<sup>box</sup>      | #Params  |   FLOPs   | FPS  |
+|:-------------------------:|:--------------------------:|:--------:|:---------:|:----:|
+|        TridentNet        |            52.9             | 32.80 M  | 822.13 G  | 4.2  |
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Li, Yanghao, et al. ‘Scale-Aware Trident Networks for Object Detection’. ArXiv:1901.01892 [Cs], Aug. 2019. arXiv.org, http://arxiv.org/abs/1901.01892.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -221,3 +221,5 @@ values:
     display_name: ConvMixer
   - id: tnt
     display_name: Transformer iN Transformer
+  - id: tridentnet
+    display_name: TridentNet


### PR DESCRIPTION
This PR adds SavedModel, TF Lite, and TFJS models for Faster RCNN trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset introduced in our very recent paper.
[![arXiv](https://img.shields.io/badge/paper-arXiv:2112.09569-b31b1b.svg?logo=arxiv)](https://arxiv.org/abs/2112.09569)

|   Method    | AP<sup>box</sup> | AP<sub>50</sub><sup>box</sup> | AP<sub>75</sub><sup>box</sup> | AP<sub>S</sub><sup>box</sup> | AP<sub>M</sub><sup>box</sup> | AP<sub>L</sub><sup>box</sup> | Train Config | TensorBoard.dev |
|:-----------:|:--------------------------:|:---------------------------------------:|:---------------------------------------:|:----------------------------------------:|:----------------------------------------:|:----------------------------------------:|:-------:|:------:|
|         TridentNet         |    52.9    |        85.1       |        58.3       |       42.6       |       41.3       |       62.6       | [config](https://github.com/Rishit-dagli/CPPE-Dataset/blob/main/configs/tridentnet_r50_caffe_mstrain_3x_coco.py) | [tb.dev](https://tensorboard.dev/experiment/9O0MAFnlRMWWezz1TbLYGQ/) |

---

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
