### PR TITLE
add KLUE BERT/RoBERTa models

### DIFF
--- a/assets/docs/jeongukjae/models/klue_bert_cased_L-12_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/klue_bert_cased_L-12_H-768_A-12/1.md
@@ -8,6 +8,7 @@ Pretrained BERT Model on Korean Language.
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
+<!-- license: cc-by-sa-4.0 -->
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/klue_bert_cased_L-12_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/klue_bert_cased_L-12_H-768_A-12/1.md
@@ -1,0 +1,81 @@
+# Module jeongukjae/klue_bert_cased_L-12_H-768_A-12/1
+
+Pretrained BERT Model on Korean Language.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/klue-roberta/klue_bert_cased_L-12_H-768_A-12.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+## Overview
+
+This model is a tensorflow conversion of [`klue/bert-base`](https://huggingface.co/klue/bert-base) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/klue/bert-base), [Official GitHub](https://github.com/KLUE-benchmark/KLUE), or [KLUE paper](https://arxiv.org/abs/2105.09680).
+
+## Example Use
+
+You can use this model with an interface that is almost identical to bert's in tfhub.
+
+For example, you can define a text embedding model with below code.
+
+```python
+# define a text embedding model
+text_input = tf.keras.layers.Input(shape=(), dtype=tf.string)
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_bert_cased_preprocess/1")
+encoder_inputs = preprocessor(text_input)
+
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_bert_cased_L-12_H-768_A-12/1", trainable=True)
+encoder_outputs = encoder(encoder_inputs)
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(text_input, pooled_output)
+
+# You can embed your sentences as follows
+sentences = tf.constant(["(your text here)"])
+print(model(sentences))
+```
+
+### Build model for multi text inputs
+
+If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/klue_bert_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_bert_cased_L-12_H-768_A-12/1", trainable=True)
+
+text_inputs = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+]
+tokenized_inputs = [tokenize(segment) for segment in text_inputs]
+encoder_inputs = bert_pack_inputs(tokenized_inputs)
+encoder_outputs = encoder(encoder_inputs)
+
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(text_inputs, pooled_output)
+
+# You can pass your sentences as follows
+hypotheses = tf.constant(["(your hypothesis text here)"])
+premises = tf.constant(["(your premise text here)"])
+print(model([hypotheses, premises]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+* `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
+* `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
+* `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+
+## References
+
+* [`klue/bert-base` Model card in HuggingFace model hub](https://huggingface.co/klue/bert-base)
+* [KLUE-benchmark GitHub](https://github.com/KLUE-benchmark/KLUE)
+* [KLUE paper](https://arxiv.org/abs/2105.09680)

--- a/assets/docs/jeongukjae/models/klue_bert_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/klue_bert_cased_preprocess/1.md
@@ -7,6 +7,7 @@ Text preprocessing model for `jeongukjae/klue_bert_cased_L-12_H-768_A-12/1`.
 <!-- fine-tunable: false -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
+<!-- license: cc-by-sa-4.0 -->
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/klue_bert_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/klue_bert_cased_preprocess/1.md
@@ -1,0 +1,66 @@
+# Module jeongukjae/klue_bert_cased_preprocess/1
+
+Text preprocessing model for `jeongukjae/klue_bert_cased_L-12_H-768_A-12/1`.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/klue-roberta/klue_bert_cased_preprocess.tar.gz -->
+<!-- task: text-preprocessing -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+## Overview
+
+This model is a text preprocessing model for [`jeongukjae/klue_bert_cased_L-12_H-768_A-12/1`](https://tfhub.dev/jeongukjae/klue_bert_cased_L-12_H-768_A-12/1).
+
+This model has no trainable parameters and can be used in an input pipeline outside the training loop.
+
+## Prerequisites
+
+This model uses [`BertTokenizer`](https://www.tensorflow.org/text/api_docs/python/text/BertTokenizer) in TensorFlow Text. You can register required ops as follows.
+
+```python
+# Install it with "pip install tensorflow-text"
+import tensorflow_text as text
+```
+
+## Usage
+
+This model supports preprocessing single or multi segment text inputs.
+
+### Preprocess single text segment
+
+```python
+sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_bert_cased_preprocess/1")
+encoder_inputs = preprocessor(sentences)
+```
+
+### Preprocess multiple text segments
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/klue_bert_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+# You can use different sequence length like below. (default is 128)
+#
+# bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs, arguments=dict(seq_length=64))
+
+sentences = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_a"),
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_b"),
+]
+tokenized_sentences = [tokenize(segment) for segment in sentences]
+encoder_inputs = bert_pack_inputs(tokenized_sentences)
+```
+
+### Output details
+
+The result of preprocessing is a batch of fixed-length input sequences for the BERT encoder.
+
+An input sequence starts with one start-of-sequence token, followed by the tokenized segments, each terminated by one end-of-segment token. Remaining positions up to `seq_length`, if any, are filled up with padding tokens. If an input sequence would exceed `seq_length`, the tokenized segments in it are truncated to prefixes of approximately equal sizes to fit exactly.
+
+The `encoder_inputs` are a dict of three int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of input sequences as follows:
+
+* `"input_word_ids"`: has the token ids of the input sequences.
+* `"input_mask"`: has value 1 at the position of all input tokens present before padding and value 0 for the padding tokens.
+* `"input_type_ids"`: has the index of the input segment that gave rise to the input token at the respective position.

--- a/assets/docs/jeongukjae/models/klue_roberta_cased_L-12_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/klue_roberta_cased_L-12_H-768_A-12/1.md
@@ -8,6 +8,7 @@ Pretrained RoBERTa Model on Korean Language.
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
+<!-- license: cc-by-sa-4.0 -->
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/klue_roberta_cased_L-12_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/klue_roberta_cased_L-12_H-768_A-12/1.md
@@ -1,0 +1,81 @@
+# Module jeongukjae/klue_roberta_cased_L-12_H-768_A-12/1
+
+Pretrained RoBERTa Model on Korean Language.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/klue-roberta/klue_roberta_cased_L-12_H-768_A-12.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+## Overview
+
+This model is a tensorflow conversion of [`klue/roberta-base`](https://huggingface.co/klue/roberta-base) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/klue/roberta-base), [Official GitHub](https://github.com/KLUE-benchmark/KLUE), or [KLUE paper](https://arxiv.org/abs/2105.09680).
+
+## Example Use
+
+You can use this model with an interface that is almost identical to bert's in tfhub.
+
+For example, you can define a text embedding model with below code.
+
+```python
+# define a text embedding model
+text_input = tf.keras.layers.Input(shape=(), dtype=tf.string)
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_preprocess/1")
+encoder_inputs = preprocessor(text_input)
+
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_L-12_H-768_A-12/1", trainable=True)
+encoder_outputs = encoder(encoder_inputs)
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(text_input, pooled_output)
+
+# You can embed your sentences as follows
+sentences = tf.constant(["(your text here)"])
+print(model(sentences))
+```
+
+### Build model for multi text inputs
+
+If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/klue_roberta_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_L-12_H-768_A-12/1", trainable=True)
+
+text_inputs = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+]
+tokenized_inputs = [tokenize(segment) for segment in text_inputs]
+encoder_inputs = bert_pack_inputs(tokenized_inputs)
+encoder_outputs = encoder(encoder_inputs)
+
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(text_inputs, pooled_output)
+
+# You can pass your sentences as follows
+hypotheses = tf.constant(["(your hypothesis text here)"])
+premises = tf.constant(["(your premise text here)"])
+print(model([hypotheses, premises]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+* `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
+* `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
+* `"encoder_outputs"`: A list of 12 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+
+## References
+
+* [`klue/roberta-base` Model card in HuggingFace model hub](https://huggingface.co/klue/roberta-base)
+* [KLUE-benchmark GitHub](https://github.com/KLUE-benchmark/KLUE)
+* [KLUE paper](https://arxiv.org/abs/2105.09680)

--- a/assets/docs/jeongukjae/models/klue_roberta_cased_L-24_H-1024_A-16/1.md
+++ b/assets/docs/jeongukjae/models/klue_roberta_cased_L-24_H-1024_A-16/1.md
@@ -1,0 +1,81 @@
+# Module jeongukjae/klue_roberta_cased_L-24_H-1024_A-16/1
+
+Pretrained RoBERTa Model on Korean Language.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/klue-roberta/klue_roberta_cased_L-24_H-1024_A-16.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+## Overview
+
+This model is a tensorflow conversion of [`klue/roberta-large`](https://huggingface.co/klue/roberta-large) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/klue/roberta-large), [Official GitHub](https://github.com/KLUE-benchmark/KLUE), or [KLUE paper](https://arxiv.org/abs/2105.09680).
+
+## Example Use
+
+You can use this model with an interface that is almost identical to bert's in tfhub.
+
+For example, you can define a text embedding model with below code.
+
+```python
+# define a text embedding model
+text_input = tf.keras.layers.Input(shape=(), dtype=tf.string)
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_preprocess/1")
+encoder_inputs = preprocessor(text_input)
+
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_L-24_H-1024_A-16/1", trainable=True)
+encoder_outputs = encoder(encoder_inputs)
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 1024].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 1024].
+
+model = tf.keras.Model(text_input, pooled_output)
+
+# You can embed your sentences as follows
+sentences = tf.constant(["(your text here)"])
+print(model(sentences))
+```
+
+### Build model for multi text inputs
+
+If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/klue_roberta_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_L-24_H-1024_A-16/1", trainable=True)
+
+text_inputs = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+]
+tokenized_inputs = [tokenize(segment) for segment in text_inputs]
+encoder_inputs = bert_pack_inputs(tokenized_inputs)
+encoder_outputs = encoder(encoder_inputs)
+
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 1024].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 1024].
+
+model = tf.keras.Model(text_inputs, pooled_output)
+
+# You can pass your sentences as follows
+hypotheses = tf.constant(["(your hypothesis text here)"])
+premises = tf.constant(["(your premise text here)"])
+print(model([hypotheses, premises]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+* `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(1024 for this model)]`. You can use this output as the sentence representation.
+* `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(1024)]`.
+* `"encoder_outputs"`: A list of 24 tensors of shapes are `[batch size, sequence length, hidden size(1024)]` with the outputs of the i-th Transformer block.
+
+## References
+
+* [`klue/roberta-large` Model card in HuggingFace model hub](https://huggingface.co/klue/roberta-large)
+* [KLUE-benchmark GitHub](https://github.com/KLUE-benchmark/KLUE)
+* [KLUE paper](https://arxiv.org/abs/2105.09680)

--- a/assets/docs/jeongukjae/models/klue_roberta_cased_L-24_H-1024_A-16/1.md
+++ b/assets/docs/jeongukjae/models/klue_roberta_cased_L-24_H-1024_A-16/1.md
@@ -8,6 +8,7 @@ Pretrained RoBERTa Model on Korean Language.
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
+<!-- license: cc-by-sa-4.0 -->
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/klue_roberta_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/klue_roberta_cased_L-6_H-768_A-12/1.md
@@ -1,0 +1,81 @@
+# Module jeongukjae/klue_roberta_cased_L-6_H-768_A-12/1
+
+Pretrained RoBERTa Model on Korean Language.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/klue-roberta/klue_roberta_cased_L-6_H-768_A-12.tar.gz -->
+<!-- network-architecture: transformer -->
+<!-- task: text-embedding -->
+<!-- fine-tunable: true -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+## Overview
+
+This model is a tensorflow conversion of [`klue/roberta-small`](https://huggingface.co/klue/roberta-small) from the HuggingFace model hub. It is exported as TF SavedModel in [this repository(jeongukjae/huggingface-to-tfhub)](https://github.com/jeongukjae/huggingface-to-tfhub). For more descriptions or training details, you can check [the model card in HuggingFace model hub](https://huggingface.co/klue/roberta-small), [Official GitHub](https://github.com/KLUE-benchmark/KLUE), or [KLUE paper](https://arxiv.org/abs/2105.09680).
+
+## Example Use
+
+You can use this model with an interface that is almost identical to bert's in tfhub.
+
+For example, you can define a text embedding model with below code.
+
+```python
+# define a text embedding model
+text_input = tf.keras.layers.Input(shape=(), dtype=tf.string)
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_preprocess/1")
+encoder_inputs = preprocessor(text_input)
+
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_L-6_H-768_A-12/1", trainable=True)
+encoder_outputs = encoder(encoder_inputs)
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(text_input, pooled_output)
+
+# You can embed your sentences as follows
+sentences = tf.constant(["(your text here)"])
+print(model(sentences))
+```
+
+### Build model for multi text inputs
+
+If you want a model for multi text inputs (i.e. fine-tuning with nli datasets), you can build as follows.
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/klue_roberta_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+encoder = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_L-6_H-768_A-12/1", trainable=True)
+
+text_inputs = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+    tf.keras.layers.Input(shape=(), dtype=tf.string),
+]
+tokenized_inputs = [tokenize(segment) for segment in text_inputs]
+encoder_inputs = bert_pack_inputs(tokenized_inputs)
+encoder_outputs = encoder(encoder_inputs)
+
+pooled_output = encoder_outputs["pooled_output"]      # [batch_size, 768].
+sequence_output = encoder_outputs["sequence_output"]  # [batch_size, seq_length, 768].
+
+model = tf.keras.Model(text_inputs, pooled_output)
+
+# You can pass your sentences as follows
+hypotheses = tf.constant(["(your hypothesis text here)"])
+premises = tf.constant(["(your premise text here)"])
+print(model([hypotheses, premises]))
+```
+
+## Output details
+
+The outputs of this model are a dict, and each entries are as follows:
+
+* `"pooled_output"`: pooled output of the entire sequence with shape `[batch size, hidden size(768 for this model)]`. You can use this output as the sentence representation.
+* `"sequence_output"`: representations of every token in the input sequence with shape `[batch size, max sequence length, hidden size(768)]`.
+* `"encoder_outputs"`: A list of 6 tensors of shapes are `[batch size, sequence length, hidden size(768)]` with the outputs of the i-th Transformer block.
+
+## References
+
+* [`klue/roberta-small` Model card in HuggingFace model hub](https://huggingface.co/klue/roberta-small)
+* [KLUE-benchmark GitHub](https://github.com/KLUE-benchmark/KLUE)
+* [KLUE paper](https://arxiv.org/abs/2105.09680)

--- a/assets/docs/jeongukjae/models/klue_roberta_cased_L-6_H-768_A-12/1.md
+++ b/assets/docs/jeongukjae/models/klue_roberta_cased_L-6_H-768_A-12/1.md
@@ -8,6 +8,7 @@ Pretrained RoBERTa Model on Korean Language.
 <!-- fine-tunable: true -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
+<!-- license: cc-by-sa-4.0 -->
 
 ## Overview
 

--- a/assets/docs/jeongukjae/models/klue_roberta_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/klue_roberta_cased_preprocess/1.md
@@ -1,0 +1,66 @@
+# Module jeongukjae/klue_roberta_cased_preprocess/1
+
+Text preprocessing model for KLUE-RoBERTa.
+
+<!-- asset-path: https://storage.googleapis.com/jeongukjae-tf-models/klue-roberta/klue_roberta_cased_preprocess.tar.gz -->
+<!-- task: text-preprocessing -->
+<!-- fine-tunable: false -->
+<!-- format: saved_model_2 -->
+<!-- language: ko -->
+
+## Overview
+
+This model is a text preprocessing model for KLUE-RoBERTa.
+
+This model has no trainable parameters and can be used in an input pipeline outside the training loop.
+
+## Prerequisites
+
+This model uses [`BertTokenizer`](https://www.tensorflow.org/text/api_docs/python/text/BertTokenizer) in TensorFlow Text. You can register required ops as follows.
+
+```python
+# Install it with "pip install tensorflow-text"
+import tensorflow_text as text
+```
+
+## Usage
+
+This model supports preprocessing single or multi segment text inputs.
+
+### Preprocess single text segment
+
+```python
+sentences = tf.keras.layers.Input(shape=(), dtype=tf.string, name="sentences")
+preprocessor = hub.KerasLayer("https://tfhub.dev/jeongukjae/klue_roberta_cased_preprocess/1")
+encoder_inputs = preprocessor(sentences)
+```
+
+### Preprocess multiple text segments
+
+```python
+preprocessor = hub.load("https://tfhub.dev/jeongukjae/klue_roberta_cased_preprocess/1")
+tokenize = hub.KerasLayer(preprocessor.tokenize)
+bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs)
+# You can use different sequence length like below. (default is 128)
+#
+# bert_pack_inputs = hub.KerasLayer(preprocessor.bert_pack_inputs, arguments=dict(seq_length=64))
+
+sentences = [
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_a"),
+    tf.keras.layers.Input(shape=(), dtype=tf.string, name="segment_b"),
+]
+tokenized_sentences = [tokenize(segment) for segment in sentences]
+encoder_inputs = bert_pack_inputs(tokenized_sentences)
+```
+
+### Output details
+
+The result of preprocessing is a batch of fixed-length input sequences for the BERT encoder.
+
+An input sequence starts with one start-of-sequence token, followed by the tokenized segments, each terminated by one end-of-segment token. Remaining positions up to `seq_length`, if any, are filled up with padding tokens. If an input sequence would exceed `seq_length`, the tokenized segments in it are truncated to prefixes of approximately equal sizes to fit exactly.
+
+The `encoder_inputs` are a dict of three int32 Tensors, all with shape `[batch_size, seq_length]`, whose elements represent the batch of input sequences as follows:
+
+* `"input_word_ids"`: has the token ids of the input sequences.
+* `"input_mask"`: has value 1 at the position of all input tokens present before padding and value 0 for the padding tokens.
+* `"input_type_ids"`: was the index of the input segment that gave rise to the input token at the respective position. But for RoBERTa, this value always has the value 0 at all positions.

--- a/assets/docs/jeongukjae/models/klue_roberta_cased_preprocess/1.md
+++ b/assets/docs/jeongukjae/models/klue_roberta_cased_preprocess/1.md
@@ -7,6 +7,7 @@ Text preprocessing model for KLUE-RoBERTa.
 <!-- fine-tunable: false -->
 <!-- format: saved_model_2 -->
 <!-- language: ko -->
+<!-- license: cc-by-sa-4.0 -->
 
 ## Overview
 

--- a/tags/license.yaml
+++ b/tags/license.yaml
@@ -38,5 +38,8 @@ values:
   - id: cc-by-nc-4.0
     display_name: CC-BY-NC-4.0
     url: https://creativecommons.org/licenses/by-nc/4.0
+  - id: cc-by-sa-4.0
+    display_name: CC-BY-SA-4.0
+    url: https://creativecommons.org/licenses/by-sa/4.0
   - id: custom
     display_name: custom


### PR DESCRIPTION
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.

---

I have converted [KLUE RoBERTa/BERT models](https://github.com/KLUE-benchmark/KLUE) to TensorFlow in [this repository](https://github.com/jeongukjae/huggingface-to-tfhub), and want to add them to tfhub.dev. For that, I added a license (cc-by-sa-4.0) that is a license of original models in `tags/license.yaml`.