### PR TITLE
Add rest of the models trained on CPPE-5

### DIFF
--- a/assets/docs/rishit-dagli/collections/cppe5/1.md
+++ b/assets/docs/rishit-dagli/collections/cppe5/1.md
@@ -7,7 +7,7 @@ Collection of the models trained on the new CPPE-5 dataset [1].
 
 ## Overview
 
-This collection contains seven different models that were pre-trained on the CPPE-5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+This collection contains seven different models that were pre-trained on the CPPE-5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 The training code for these can be found in our paper GitHub repository [2].
 

--- a/assets/docs/rishit-dagli/collections/cppe5/1.md
+++ b/assets/docs/rishit-dagli/collections/cppe5/1.md
@@ -1,0 +1,30 @@
+# Collection rishit-dagli/cppe5/1
+Collection of the models trained on the new CPPE-5 dataset [1].
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: multiple -->
+<!-- dataset: cppe-5 -->
+
+## Overview
+
+This collection contains seven different models that were pre-trained on the CPPE-5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+The training code for these can be found in our paper GitHub repository [2].
+
+## Models
+
+| Model Name | AP<sup>box</sup> | TF SavedModel | TF Lite |  TFJS  | TenosrBoard |
+| ---------- | :--------------: | :-----------: | :-----: | :----: | :---------: |
+| SSD | 29.5 | [rishit-dagli/ssd-cppe5/1](https://tfhub.dev/rishit-dagli/ssd-cppe5/1) | [rishit-dagli/ssd-cppe5-lite/1](https://tfhub.dev/rishit-dagli/ssd-cppe5-lite/1) | [rishit-dagli/ssd-cppe5-tfjs/1](https://tfhub.dev/rishit-dagli/ssd-cppe5-tfjs/1) | [tb.dev](https://tensorboard.dev/experiment/2EimzQz9Q4GCJjYsyo1MKQ/) |
+| YOLO | 38.5 | [rishit-dagli/yolo-cppe5/1](https://tfhub.dev/rishit-dagli/yolo-cppe5/1) | [rishit-dagli/yolo-cppe5-lite/1](https://tfhub.dev/rishit-dagli/yolo-cppe5-lite/1) | [rishit-dagli/yolo-cppe5-tfjs/1](https://tfhub.dev/rishit-dagli/yolo-cppe5-tfjs/1) | [tb.dev](https://tensorboard.dev/experiment/5JrpU22hRnOOOXCLKvxFyQ) |
+| Faster RCNN | 44.0 | [rishit-dagli/faster-rcnn-cppe5/1](https://tfhub.dev/rishit-dagli/faster-rcnn-cppe5/1) | [rishit-dagli/faster-rcnn-cppe5-lite/1](https://tfhub.dev/rishit-dagli/faster-rcnn-cppe5-lite/1) | [rishit-dagli/faster-rcnn-cppe5-tfjs/1](https://tfhub.dev/rishit-dagli/faster-rcnn-cppe5-tfjs/1) | [tb.dev](https://tensorboard.dev/experiment/20XQ37HgQUyMJuOlbqmVDQ/) |
+| FCOS | 44.4 | [rishit-dagli/fcos-cppe5/1](https://tfhub.dev/rishit-dagli/fcos-cppe5/1) | [rishit-dagli/fcos-cppe5-lite/1](https://tfhub.dev/rishit-dagli/fcos-cppe5-lite/1) | [rishit-dagli/fcos-cppe5-tfjs/1](https://tfhub.dev/rishit-dagli/fcos-cppe5-tfjs/1) | [tb.dev](https://tensorboard.dev/experiment/O343s1kRQIKTqs508jESDA/) |
+| FSAF | 49.2 | [rishit-dagli/fsaf-cppe5/1](https://tfhub.dev/rishit-dagli/fsaf-cppe5/1) | [rishit-dagli/fsaf-cppe5-lite/1](https://tfhub.dev/rishit-dagli/fsaf-cppe5-lite/1) | [rishit-dagli/fsaf-cppe5-tfjs/1](https://tfhub.dev/rishit-dagli/fsaf-cppe5-tfjs/1) | [tb.dev](https://tensorboard.dev/experiment/jUa0QjFJQZe68o4vbP194Q/) |
+| RegNet | 51.3 | [rishit-dagli/regnet-cppe5/1](https://tfhub.dev/rishit-dagli/regnet-cppe5/1) | [rishit-dagli/regnet-cppe5-lite/1](https://tfhub.dev/rishit-dagli/regnet-cppe5-lite/1) | [rishit-dagli/regnet-cppe5-tfjs/1](https://tfhub.dev/rishit-dagli/regnet-cppe5-tfjs/1) | [tb.dev](https://tensorboard.dev/experiment/eYyj3lwcR5O3XDbuyFZ81Q/) |
+| TridentNet | 52.9 | [rishit-dagli/tridentnet-cppe5/1](https://tfhub.dev/rishit-dagli/tridentnet-cppe5/1) | [rishit-dagli/tridentnet-cppe5-lite/1](https://tfhub.dev/rishit-dagli/tridentnet-cppe5-lite/1) | [rishit-dagli/tridentnet-cppe5-tfjs/1](https://tfhub.dev/rishit-dagli/tridentnet-cppe5-tfjs/1) | [tb.dev](https://tensorboard.dev/experiment/9O0MAFnlRMWWezz1TbLYGQ/) |
+
+## References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/collections/cppe5/1.md
+++ b/assets/docs/rishit-dagli/collections/cppe5/1.md
@@ -27,4 +27,4 @@ The training code for these can be found in our paper GitHub repository [2].
 
 [1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
 
-[3] https://github.com/Rishit-dagli/CPPE-Dataset
+[2] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/faster-rcnn-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/faster-rcnn-cppe5-lite/default/lite/1.md
@@ -5,7 +5,7 @@ TF Lite version of the Faster RCNN model (with ResNet 101 backbone) trained on t
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/faster_rcnn/lite/model.tflite -->
 
 ### Overview
-The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/faster-rcnn-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/faster-rcnn-cppe5-lite/fp16/lite/1.md
@@ -5,7 +5,7 @@ TF Lite quantized version of the Faster RCNN model (with ResNet 101 backbone) tr
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/faster_rcnn/lite/model_fp16.tflite -->
 
 ### Overview
-The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/faster-rcnn-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/faster-rcnn-cppe5-tfjs/default/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS version of the Faster RCNN model (with ResNet 101 backbone) trained on the 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/faster_rcnn/tfjs/faster_rcnn_tfjs.tar.gz -->
 
 ### Overview
-The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/faster-rcnn-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/faster-rcnn-cppe5-tfjs/fp16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS FP16 quantized version of the Faster RCNN model (with ResNet 101 backbone) 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/faster_rcnn/tfjs/faster_rcnn_fp16.tar.gz -->
 
 ### Overview
-The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/faster-rcnn-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/faster-rcnn-cppe5-tfjs/uint16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint16 quantized version of the Faster RCNN model (with ResNet 101 backbone
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/faster_rcnn/tfjs/faster_rcnn_uint16.tar.gz -->
 
 ### Overview
-The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/faster-rcnn-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/faster-rcnn-cppe5-tfjs/uint8/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint8 quantized version of the Faster RCNN model (with ResNet 101 backbone)
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/faster_rcnn/tfjs/faster_rcnn_uint8.tar.gz -->
 
 ### Overview
-The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/faster-rcnn-cppe5/1.md
+++ b/assets/docs/rishit-dagli/faster-rcnn-cppe5/1.md
@@ -14,7 +14,7 @@ The Faster RCNN model (with ResNet 101 backbone) trained on the CPPE - 5 (Medica
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
 ### Overview
-The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The Faster RCNN model was proposed by Ren et al. in the paper "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks" [2]. The Faster RCNN models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fcos-cppe5-lite/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-lite/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/fcos-cppe5-lite/1
+The FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TF Lite Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: fcos -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/fcos-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-lite/default/lite/1.md
@@ -5,7 +5,7 @@ TF Lite version of the FCOS model (with ResNet 101 backbone) trained on the CPPE
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/lite/model.tflite -->
 
 ### Overview
-The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fcos-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-lite/default/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/fcos-cppe5-lite/default/1
+TF Lite version of the FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fcos-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/lite/model.tflite -->
+
+### Overview
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Tian, Zhi, et al. "Fcos: Fully convolutional one-stage object detection." Proceedings of the IEEE/CVF international conference on computer vision. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fcos-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-lite/fp16/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/fcos-cppe5-lite/fp16/1
+TF Lite quantized version of the FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fcos-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/lite/model_f16.tflite -->
+
+### Overview
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Tian, Zhi, et al. "Fcos: Fully convolutional one-stage object detection." Proceedings of the IEEE/CVF international conference on computer vision. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fcos-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-lite/fp16/lite/1.md
@@ -5,7 +5,7 @@ TF Lite quantized version of the FCOS model (with ResNet 101 backbone) trained o
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/lite/model_f16.tflite -->
 
 ### Overview
-The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/fcos-cppe5-tfjs/1
+The FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TFJS Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: fcos -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/default/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/fcos-cppe5-tfjs/default/1
+TFJS version of the FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fcos-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tfjs/fcos_tfjs.tar.gz -->
+
+### Overview
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/fcos-cppe5/default/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Tian, Zhi, et al. "Fcos: Fully convolutional one-stage object detection." Proceedings of the IEEE/CVF international conference on computer vision. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/default/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS version of the FCOS model (with ResNet 101 backbone) trained on the CPPE - 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tfjs/fcos_tfjs.tar.gz -->
 
 ### Overview
-The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/fp16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS FP16 quantized version of the FCOS model (with ResNet 101 backbone) trained
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tfjs/fcos_fp16.tar.gz -->
 
 ### Overview
-The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/fp16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/fcos-cppe5-tfjs/fp16/1
+TFJS FP16 quantized version of the FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fcos-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tfjs/fcos_fp16.tar.gz -->
+
+### Overview
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/fcos-cppe5-tfjs/fp16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `float16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Tian, Zhi, et al. "Fcos: Fully convolutional one-stage object detection." Proceedings of the IEEE/CVF international conference on computer vision. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/uint16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/fcos-cppe5-tfjs/uint16/1
+TFJS uint16 quantized version of the FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fcos-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tfjs/fcos_uint8.tar.gz -->
+
+### Overview
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/fcos-cppe5-tfjs/uint16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Tian, Zhi, et al. "Fcos: Fully convolutional one-stage object detection." Proceedings of the IEEE/CVF international conference on computer vision. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/uint16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint16 quantized version of the FCOS model (with ResNet 101 backbone) train
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tfjs/fcos_uint8.tar.gz -->
 
 ### Overview
-The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/uint8/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint8 quantized version of the FCOS model (with ResNet 101 backbone) traine
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tfjs/fcos_uint8.tar.gz -->
 
 ### Overview
-The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fcos-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5-tfjs/uint8/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/fcos-cppe5-tfjs/uint8/1
+TFJS uint8 quantized version of the FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fcos-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tfjs/fcos_uint8.tar.gz -->
+
+### Overview
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/fcos-cppe5-tfjs/uint8/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint8` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Tian, Zhi, et al. "Fcos: Fully convolutional one-stage object detection." Proceedings of the IEEE/CVF international conference on computer vision. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fcos-cppe5/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5/1.md
@@ -14,7 +14,7 @@ The FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Perso
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
 ### Overview
-The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fcos-cppe5/1.md
+++ b/assets/docs/rishit-dagli/fcos-cppe5/1.md
@@ -1,0 +1,72 @@
+# Module rishit-dagli/fcos-cppe5/1
+
+The FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: fcos -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fcos/tf_fcos.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+The FCOS model was proposed by Tian et al. in their paper "FCOS: Fully Convolutional One-Stage Object Detection" [2]. The FCOS model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Model Performance
+Here we present the performance of the FCOS model on the CPPE - 5 dataset. For evaluation, we adopt the metrics from the COCO detection evaluation criteria, including the mean Average Precision (AP) across IoU thresholds ranging from 0.50 to 0.95 at different scales.
+
+|   Method    | AP<sup>box</sup> | AP<sub>50</sub><sup>box</sup> | AP<sub>75</sub><sup>box</sup> | AP<sub>S</sub><sup>box</sup> | AP<sub>M</sub><sup>box</sup> | AP<sub>L</sub><sup>box</sup> |
+| :---------: | :--------------: | :---------------------------: | :---------------------------: | :--------------------------: | :--------------------------: | :--------------------------: |
+| FCOS | 44.4 | 79.5 | 45.9 | 36.7 | 39.2 | 51.7 |
+
+### Usage
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/fcos-cppe5/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['dets']`: A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- `outputs['labels']`: A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+It can also be used within a KerasLayer:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/fcos-cppe5/1")
+```
+
+### Model Complexity
+We measure the model complexity in terms of the number of parameters FLOPS and FPS. The inference speed FPS (Frames per second) for detector is measured on a machine with 1 Tesla V100 GPU.
+
+|          Method           |      AP<sup>box</sup>      | #Params  |   FLOPs   | FPS  |
+|:-------------------------:|:--------------------------:|:--------:|:---------:|:----:|
+|        FCOS               |            44.4            | 60.14 M  | 282.75 G  | 15.6 |
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Tian, Zhi, et al. "Fcos: Fully convolutional one-stage object detection." Proceedings of the IEEE/CVF international conference on computer vision. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fsaf-cppe5-lite/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-lite/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/fsaf-cppe5-lite/1
+The FCOS model (with ResNet 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TF Lite Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: fsaf -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/fsaf-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-lite/default/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/fsaf-cppe5-lite/default/1
+TF Lite version of the FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fsaf-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/lite/model.tflite -->
+
+### Overview
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Zhu, Chenchen, Yihui He, and Marios Savvides. "Feature selective anchor-free module for single-shot object detection." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fsaf-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-lite/default/lite/1.md
@@ -5,7 +5,7 @@ TF Lite version of the FSAF model (with ResNeXt 101 backbone) trained on the CPP
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/lite/model.tflite -->
 
 ### Overview
-The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fsaf-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-lite/fp16/lite/1.md
@@ -5,7 +5,7 @@ TF Lite quantized version of the FSAF model (with ResNeXt 101 backbone) trained 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/lite/model_f16.tflite -->
 
 ### Overview
-The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fsaf-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-lite/fp16/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/fsaf-cppe5-lite/fp16/1
+TF Lite quantized version of the FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fsaf-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/lite/model_f16.tflite -->
+
+### Overview
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Zhu, Chenchen, Yihui He, and Marios Savvides. "Feature selective anchor-free module for single-shot object detection." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/fsaf-cppe5-tfjs/1
+The FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TFJS Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: fsaf -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/default/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/fsaf-cppe5-tfjs/default/1
+TFJS version of the FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fsaf-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tfjs/fsaf_tfjs.tar.gz -->
+
+### Overview
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/fsaf-cppe5/default/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Zhu, Chenchen, Yihui He, and Marios Savvides. "Feature selective anchor-free module for single-shot object detection." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/default/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS version of the FSAF model (with ResNeXt 101 backbone) trained on the CPPE -
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tfjs/fsaf_tfjs.tar.gz -->
 
 ### Overview
-The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/fp16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS FP16 quantized version of the FSAF model (with ResNeXt 101 backbone) traine
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tfjs/fsaf_fp16.tar.gz -->
 
 ### Overview
-The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/fp16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/fsaf-cppe5-tfjs/fp16/1
+TFJS FP16 quantized version of the FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fsaf-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tfjs/fsaf_fp16.tar.gz -->
+
+### Overview
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/fsaf-cppe5-tfjs/fp16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `float16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Zhu, Chenchen, Yihui He, and Marios Savvides. "Feature selective anchor-free module for single-shot object detection." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/uint16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint16 quantized version of the FSAF model (with ResNeXt 101 backbone) trai
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tfjs/fsaf_uint8.tar.gz -->
 
 ### Overview
-The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/uint16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/fsaf-cppe5-tfjs/uint16/1
+TFJS uint16 quantized version of the FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fsaf-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tfjs/fsaf_uint8.tar.gz -->
+
+### Overview
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/fsaf-cppe5-tfjs/uint16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Zhu, Chenchen, Yihui He, and Marios Savvides. "Feature selective anchor-free module for single-shot object detection." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/uint8/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/fsaf-cppe5-tfjs/uint8/1
+TFJS uint8 quantized version of he FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/fsaf-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tfjs/fsaf_uint8.tar.gz -->
+
+### Overview
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/fsaf-cppe5-tfjs/uint8/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint8` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Zhu, Chenchen, Yihui He, and Marios Savvides. "Feature selective anchor-free module for single-shot object detection." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5-tfjs/uint8/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint8 quantized version of he FSAF model (with ResNeXt 101 backbone) traine
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tfjs/fsaf_uint8.tar.gz -->
 
 ### Overview
-The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fsaf-cppe5/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5/1.md
@@ -14,7 +14,7 @@ The FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Pers
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
 ### Overview
-The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/fsaf-cppe5/1.md
+++ b/assets/docs/rishit-dagli/fsaf-cppe5/1.md
@@ -1,0 +1,72 @@
+# Module rishit-dagli/fsaf-cppe5/1
+
+The FSAF model (with ResNeXt 101 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: fsaf -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/fsaf/tf_fsaf.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+The FSAF model was proposed by Zhu et al. in their paper "Feature Selective Anchor-Free Module for Single-Shot Object Detection" [2]. The FSAF model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Model Performance
+Here we present the performance of the FSAF model on the CPPE - 5 dataset. For evaluation, we adopt the metrics from the COCO detection evaluation criteria, including the mean Average Precision (AP) across IoU thresholds ranging from 0.50 to 0.95 at different scales.
+
+|   Method    | AP<sup>box</sup> | AP<sub>50</sub><sup>box</sup> | AP<sub>75</sub><sup>box</sup> | AP<sub>S</sub><sup>box</sup> | AP<sub>M</sub><sup>box</sup> | AP<sub>L</sub><sup>box</sup> |
+| :---------: | :--------------: | :---------------------------: | :---------------------------: | :--------------------------: | :--------------------------: | :--------------------------: |
+| FSAF | 49.2 | 84.7 | 48.2 | 45.3 | 39.6 | 56.7 |
+
+### Usage
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/fsaf-cppe5/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['dets']`: A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- `outputs['labels']`: A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+It can also be used within a KerasLayer:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/fsaf-cppe5/1")
+```
+
+### Model Complexity
+We measure the model complexity in terms of the number of parameters FLOPS and FPS. The inference speed FPS (Frames per second) for detector is measured on a machine with 1 Tesla V100 GPU.
+
+|          Method           |      AP<sup>box</sup>      | #Params  |   FLOPs   | FPS  |
+|:-------------------------:|:--------------------------:|:--------:|:---------:|:----:|
+|        FSAF               |            49.2            |  93.75 M |  435.88 G | 5.6  |
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Zhu, Chenchen, Yihui He, and Marios Savvides. "Feature selective anchor-free module for single-shot object detection." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/regnet-cppe5-lite/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-lite/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/regnet-cppe5-lite/1
+The RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TF Lite Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: regnetx -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/regnet-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-lite/default/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/regnet-cppe5-lite/default/1
+TF Lite version of the RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/regnet-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/lite/model.tflite -->
+
+### Overview
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Radosavovic, Ilija, et al. "Designing network design spaces." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2020.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/regnet-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-lite/default/lite/1.md
@@ -5,7 +5,7 @@ TF Lite version of the RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Pe
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/lite/model.tflite -->
 
 ### Overview
-The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/regnet-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-lite/fp16/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/regnet-cppe5-lite/fp16/1
+TF Lite quantized version of the RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/regnet-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/lite/model_f16.tflite -->
+
+### Overview
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Radosavovic, Ilija, et al. "Designing network design spaces." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2020.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/regnet-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-lite/fp16/lite/1.md
@@ -5,7 +5,7 @@ TF Lite quantized version of the RegNet model (3.2 GF) trained on the CPPE - 5 (
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/lite/model_f16.tflite -->
 
 ### Overview
-The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/regnet-cppe5-tfjs/1
+The RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TFJS Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: regnetx -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/default/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS version of the RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Perso
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tfjs/regnet_tfjs.tar.gz -->
 
 ### Overview
-The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/default/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/regnet-cppe5-tfjs/default/1
+TFJS version of the RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/regnet-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tfjs/regnet_tfjs.tar.gz -->
+
+### Overview
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/regnet-cppe5/default/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Radosavovic, Ilija, et al. "Designing network design spaces." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2020.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/fp16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/regnet-cppe5-tfjs/fp16/1
+TFJS FP16 quantized version of the RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/regnet-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tfjs/regnet_fp16.tar.gz -->
+
+### Overview
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/regnet-cppe5-tfjs/fp16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `float16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Radosavovic, Ilija, et al. "Designing network design spaces." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2020.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/fp16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS FP16 quantized version of the RegNet model (3.2 GF) trained on the CPPE - 5
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tfjs/regnet_fp16.tar.gz -->
 
 ### Overview
-The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/uint16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint16 quantized version of the RegNet model (3.2 GF) trained on the CPPE -
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tfjs/regnet_uint8.tar.gz -->
 
 ### Overview
-The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/uint16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/regnet-cppe5-tfjs/uint16/1
+TFJS uint16 quantized version of the RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/regnet-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tfjs/regnet_uint8.tar.gz -->
+
+### Overview
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/regnet-cppe5-tfjs/uint16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Radosavovic, Ilija, et al. "Designing network design spaces." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2020.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/uint8/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint8 quantized version of the RegNet model (3.2 GF) trained on the CPPE - 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tfjs/regnet_uint8.tar.gz -->
 
 ### Overview
-The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/regnet-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5-tfjs/uint8/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/regnet-cppe5-tfjs/uint8/1
+TFJS uint8 quantized version of the RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/regnet-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tfjs/regnet_uint8.tar.gz -->
+
+### Overview
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/regnet-cppe5-tfjs/uint8/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint8` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Radosavovic, Ilija, et al. "Designing network design spaces." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2020.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/regnet-cppe5/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5/1.md
@@ -14,7 +14,7 @@ The RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective E
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
 ### Overview
-The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/regnet-cppe5/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5/1.md
@@ -8,7 +8,7 @@ The RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective E
 <!-- fine-tunable: false -->
 <!-- license: apache-2.0 -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tf_regnet.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/regnet.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/regnet-cppe5/1.md
+++ b/assets/docs/rishit-dagli/regnet-cppe5/1.md
@@ -1,0 +1,72 @@
+# Module rishit-dagli/regnet-cppe5/1
+
+The RegNet model (3.2 GF) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: regnetx -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/regnet/tf_regnet.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+The RegNet model was proposed by Radosavovic et al. in their paper "Designing network design spaces" [2]. The RegNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Model Performance
+Here we present the performance of the RegNet model on the CPPE - 5 dataset. For evaluation, we adopt the metrics from the COCO detection evaluation criteria, including the mean Average Precision (AP) across IoU thresholds ranging from 0.50 to 0.95 at different scales.
+
+|   Method    | AP<sup>box</sup> | AP<sub>50</sub><sup>box</sup> | AP<sub>75</sub><sup>box</sup> | AP<sub>S</sub><sup>box</sup> | AP<sub>M</sub><sup>box</sup> | AP<sub>L</sub><sup>box</sup> |
+| :---------: | :--------------: | :---------------------------: | :---------------------------: | :--------------------------: | :--------------------------: | :--------------------------: |
+| RegNet | 51.3 | 85.3 | 51.8 | 35.7 | 41.1 | 60.5 |
+
+### Usage
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/regnet-cppe5/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['dets']`: A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- `outputs['labels']`: A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+It can also be used within a KerasLayer:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/regnet-cppe5/1")
+```
+
+### Model Complexity
+We measure the model complexity in terms of the number of parameters FLOPS and FPS. The inference speed FPS (Frames per second) for detector is measured on a machine with 1 Tesla V100 GPU.
+
+|          Method           |      AP<sup>box</sup>      | #Params  |   FLOPs   | FPS  |
+|:-------------------------:|:--------------------------:|:--------:|:---------:|:----:|
+|        RegNet             |            51.3            | 31.50 M  | 183.29 G  | 18.2 |
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Radosavovic, Ilija, et al. "Designing network design spaces." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2020.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/ssd-cppe5-lite/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-lite/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/ssd-cppe5-lite/1
+The SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TF Lite Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: ssd -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/ssd-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-lite/default/lite/1.md
@@ -5,7 +5,7 @@ TF Lite version of the SSD model (with MobileNet backbone) trained on the CPPE -
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/lite/model.tflite -->
 
 ### Overview
-The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/ssd-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-lite/default/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/ssd-cppe5-lite/default/1
+TF Lite version of the SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/ssd-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/lite/model.tflite -->
+
+### Overview
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes variable shape inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Liu, Wei, et al. "Ssd: Single shot multibox detector." European conference on computer vision. Springer, Cham, 2016.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/ssd-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-lite/fp16/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/ssd-cppe5-lite/fp16/1
+TF Lite quantized version of the SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/ssd-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/lite/model_f16.tflite -->
+
+### Overview
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This model takes variable shape inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Liu, Wei, et al. "Ssd: Single shot multibox detector." European conference on computer vision. Springer, Cham, 2016.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/ssd-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-lite/fp16/lite/1.md
@@ -5,7 +5,7 @@ TF Lite quantized version of the SSD model (with MobileNet backbone) trained on 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/lite/model_f16.tflite -->
 
 ### Overview
-The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/faster-rcnn-cppe5-tfjs/1
+The SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TFJS Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: ssd -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/1.md
@@ -1,4 +1,4 @@
-# Placeholder rishit-dagli/faster-rcnn-cppe5-tfjs/1
+# Placeholder rishit-dagli/ssd-cppe5-tfjs/1
 The SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TFJS Format.
 
 <!-- task: image-object-detection -->

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/default/tfjs/1.md
@@ -1,0 +1,53 @@
+# Tfjs rishit-dagli/ssd-cppe5-tfjs/default/1
+TFJS version of the SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/ssd-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tfjs/tfjs.tar.gz -->
+
+### Overview
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/ssd-cppe5/default/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images could be variable, but the model was trained on images of size `[640, 640]`
+- the images should in the default `channels_last` format
+- The shape of the input tensor would ths be `(1, -1, -1, 3)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['detection_anchor_indices']`: A tensor of shape `[batch_size, 100]` containing the anchor indices for each detection.
+- `outputs['detection_boxes']`: A tensor of shape `[batch_size, 100, 4]` containing the boxes for each detection.
+- `outputs['detection_classes']`: A tensor of shape `[batch_size, 100]` containing the class indices for each detection.
+- `outputs['detection_multiclass_scores']`: A tensor of shape `[batch_size, 100, 6]` containing the class scores for each detection.
+- `outputs['detection_scores']`: A tensor of shape `[batch_size, 100]` containing the scores for each detection.
+- `outputs['num_detections']`: A tensor of shape `[batch_size]` containing the number of valid detections in each image.
+
+If use be the model also outputs the `raw_detection_boxes` and `raw_detection_scores` tensors.
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes variable shape inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Liu, Wei, et al. "Ssd: Single shot multibox detector." European conference on computer vision. Springer, Cham, 2016.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/default/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS version of the SSD model (with MobileNet backbone) trained on the CPPE - 5 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tfjs/tfjs.tar.gz -->
 
 ### Overview
-The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/fp16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS FP16 quantized version of the SSD model (with MobileNet backbone) trained o
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tfjs/tfjs_fp16.tar.gz -->
 
 ### Overview
-The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/fp16/tfjs/1.md
@@ -1,0 +1,53 @@
+# Tfjs rishit-dagli/ssd-cppe5-tfjs/fp16/1
+TFJS FP16 quantized version of the SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/ssd-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tfjs/tfjs_fp16.tar.gz -->
+
+### Overview
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/ssd-cppe5-tfjs/fp16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images could be variable, but the model was trained on images of size `[640, 640]`
+- the images should in the default `channels_last` format
+- The shape of the input tensor would ths be `(1, -1, -1, 3)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['detection_anchor_indices']`: A tensor of shape `[batch_size, 100]` containing the anchor indices for each detection.
+- `outputs['detection_boxes']`: A tensor of shape `[batch_size, 100, 4]` containing the boxes for each detection.
+- `outputs['detection_classes']`: A tensor of shape `[batch_size, 100]` containing the class indices for each detection.
+- `outputs['detection_multiclass_scores']`: A tensor of shape `[batch_size, 100, 6]` containing the class scores for each detection.
+- `outputs['detection_scores']`: A tensor of shape `[batch_size, 100]` containing the scores for each detection.
+- `outputs['num_detections']`: A tensor of shape `[batch_size]` containing the number of valid detections in each image.
+
+If use be the model also outputs the `raw_detection_boxes` and `raw_detection_scores` tensors.
+
+### Note
+
+- This model was quantized using `float16` quantization.
+- This model takes variable shape inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Liu, Wei, et al. "Ssd: Single shot multibox detector." European conference on computer vision. Springer, Cham, 2016.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/uint16/tfjs/1.md
@@ -1,0 +1,53 @@
+# Tfjs rishit-dagli/ssd-cppe5-tfjs/uint16/1
+TFJS uint16 quantized version of the SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/ssd-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tfjs/tfjs_uint16.tar.gz -->
+
+### Overview
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/ssd-cppe5-tfjs/uint16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images could be variable, but the model was trained on images of size `[640, 640]`
+- the images should in the default `channels_last` format
+- The shape of the input tensor would ths be `(1, -1, -1, 3)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['detection_anchor_indices']`: A tensor of shape `[batch_size, 100]` containing the anchor indices for each detection.
+- `outputs['detection_boxes']`: A tensor of shape `[batch_size, 100, 4]` containing the boxes for each detection.
+- `outputs['detection_classes']`: A tensor of shape `[batch_size, 100]` containing the class indices for each detection.
+- `outputs['detection_multiclass_scores']`: A tensor of shape `[batch_size, 100, 6]` containing the class scores for each detection.
+- `outputs['detection_scores']`: A tensor of shape `[batch_size, 100]` containing the scores for each detection.
+- `outputs['num_detections']`: A tensor of shape `[batch_size]` containing the number of valid detections in each image.
+
+If use be the model also outputs the `raw_detection_boxes` and `raw_detection_scores` tensors.
+
+### Note
+
+- This model was quantized using `uint16` quantization.
+- This model takes variable shape inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Liu, Wei, et al. "Ssd: Single shot multibox detector." European conference on computer vision. Springer, Cham, 2016.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/uint16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint16 quantized version of the SSD model (with MobileNet backbone) trained
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tfjs/tfjs_uint16.tar.gz -->
 
 ### Overview
-The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/uint8/tfjs/1.md
@@ -1,0 +1,53 @@
+# Tfjs rishit-dagli/ssd-cppe5-tfjs/uint8/1
+TFJS uint8 quantized version of the SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/ssd-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tfjs/tfjs_uint8.tar.gz -->
+
+### Overview
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/ssd-cppe5-tfjs/uint8/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images could be variable, but the model was trained on images of size `[640, 640]`
+- the images should in the default `channels_last` format
+- The shape of the input tensor would ths be `(1, -1, -1, 3)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['detection_anchor_indices']`: A tensor of shape `[batch_size, 100]` containing the anchor indices for each detection.
+- `outputs['detection_boxes']`: A tensor of shape `[batch_size, 100, 4]` containing the boxes for each detection.
+- `outputs['detection_classes']`: A tensor of shape `[batch_size, 100]` containing the class indices for each detection.
+- `outputs['detection_multiclass_scores']`: A tensor of shape `[batch_size, 100, 6]` containing the class scores for each detection.
+- `outputs['detection_scores']`: A tensor of shape `[batch_size, 100]` containing the scores for each detection.
+- `outputs['num_detections']`: A tensor of shape `[batch_size]` containing the number of valid detections in each image.
+
+If use be the model also outputs the `raw_detection_boxes` and `raw_detection_scores` tensors.
+
+### Note
+
+- This model was quantized using `uint8` quantization.
+- This model takes variable shape inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Liu, Wei, et al. "Ssd: Single shot multibox detector." European conference on computer vision. Springer, Cham, 2016.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/ssd-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5-tfjs/uint8/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint8 quantized version of the SSD model (with MobileNet backbone) trained 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tfjs/tfjs_uint8.tar.gz -->
 
 ### Overview
-The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/ssd-cppe5/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5/1.md
@@ -1,0 +1,78 @@
+# Module rishit-dagli/ssd-cppe5/1
+
+The SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: ssd -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/ssd/tf_ssd.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Model Performance
+Here we present the performance of the SSD model on the CPPE - 5 dataset. For evaluation, we adopt the metrics from the COCO detection evaluation criteria, including the mean Average Precision (AP) across IoU thresholds ranging from 0.50 to 0.95 at different scales.
+
+|   Method    | AP<sup>box</sup> | AP<sub>50</sub><sup>box</sup> | AP<sub>75</sub><sup>box</sup> | AP<sub>S</sub><sup>box</sup> | AP<sub>M</sub><sup>box</sup> | AP<sub>L</sub><sup>box</sup> |
+| :---------: | :--------------: | :---------------------------: | :---------------------------: | :--------------------------: | :--------------------------: | :--------------------------: |
+| SSD |       29.5       |              57.0             |              24.9             |             32.1             |             23.1             |             34.6             |
+
+### Usage
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/ssd-cppe5/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images could be variable, but the model was trained on images of size `[640, 640]`
+- the images should in the default `channels_last` format
+- The shape of the input tensor would ths be `(1, -1, -1, 3)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['detection_anchor_indices']`: A tensor of shape `[batch_size, 100]` containing the anchor indices for each detection.
+- `outputs['detection_boxes']`: A tensor of shape `[batch_size, 100, 4]` containing the boxes for each detection.
+- `outputs['detection_classes']`: A tensor of shape `[batch_size, 100]` containing the class indices for each detection.
+- `outputs['detection_multiclass_scores']`: A tensor of shape `[batch_size, 100, 6]` containing the class scores for each detection.
+- `outputs['detection_scores']`: A tensor of shape `[batch_size, 100]` containing the scores for each detection.
+- `outputs['num_detections']`: A tensor of shape `[batch_size]` containing the number of valid detections in each image.
+
+If use be the model also outputs the `raw_detection_boxes` and `raw_detection_scores` tensors.
+
+It can also be used within a KerasLayer:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/ssd-cppe5/1")
+```
+
+### Model Complexity
+We measure the model complexity in terms of the number of parameters FLOPS and FPS. The inference speed FPS (Frames per second) for detector is measured on a machine with 1 Tesla V100 GPU.
+
+|          Method           |      AP<sup>box</sup>      | #Params  |   FLOPs   | FPS  |
+|:-------------------------:|:--------------------------:|:--------:|:---------:|:----:|
+|        SSD        |            29.5            | 64.34 M  | 103.22 G  | 25.6 |
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Liu, Wei, et al. "Ssd: Single shot multibox detector." European conference on computer vision. Springer, Cham, 2016.
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/ssd-cppe5/1.md
+++ b/assets/docs/rishit-dagli/ssd-cppe5/1.md
@@ -14,7 +14,7 @@ The SSD model (with MobileNet backbone) trained on the CPPE - 5 (Medical Persona
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
 ### Overview
-The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The SSD model was proposed by Liu et al. in the paper "Ssd: Single shot multibox detector" [2]. The SSD models is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-lite/default/lite/1.md
@@ -5,7 +5,7 @@ TF Lite version of the TridentNet model (with ResNet 50 backbone) trained on the
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/lite/model.tflite -->
 
 ### Overview
-The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-lite/fp16/lite/1.md
@@ -5,7 +5,7 @@ TF Lite quantized version of the TridentNet model (with ResNet 50 backbone) trai
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/lite/model_f16.tflite -->
 
 ### Overview
-The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/default/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS version of the TridentNet model (with ResNet 50 backbone) trained on the CP
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tfjs/tridentnet_tfjs.tar.gz -->
 
 ### Overview
-The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/fp16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS FP16 quantized version of the TridentNet model (with ResNet 50 backbone) tr
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tfjs/tridentnet_fp16.tar.gz -->
 
 ### Overview
-The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/uint16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint16 quantized version of the TridentNet model (with ResNet 50 backbone) 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tfjs/tridentnet_uint8.tar.gz -->
 
 ### Overview
-The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5-tfjs/uint8/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint8 quantized version of the TridentNet model (with ResNet 50 backbone) t
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/tridentnet/tfjs/tridentnet_uint8.tar.gz -->
 
 ### Overview
-The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/tridentnet-cppe5/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5/1.md
@@ -14,7 +14,7 @@ The TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical 
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
 ### Overview
-The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The TridentNet model was proposed by Li et al. in their paper "Scale-Aware Trident Networks for Object Detection" [2]. The TridentNet model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/tridentnet-cppe5/1.md
+++ b/assets/docs/rishit-dagli/tridentnet-cppe5/1.md
@@ -3,7 +3,7 @@
 The TridentNet model (with ResNet 50 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
 
 <!-- task: image-object-detection -->
-<!-- network-architecture: faster-r-cnn -->
+<!-- network-architecture: tridentnet -->
 <!-- dataset: cppe-5 -->
 <!-- fine-tunable: false -->
 <!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/yolo-cppe5-lite/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-lite/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/yolo-cppe5-lite/1
+The YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TF Lite Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: yolo -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/yolo-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-lite/default/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/yolo-cppe5-lite/default/1
+TF Lite version of the YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/yolo-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/lite/model.tflite -->
+
+### Overview
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Redmon, Joseph, and Ali Farhadi. "Yolov3: An incremental improvement." arXiv preprint arXiv:1804.02767 (2018).
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/yolo-cppe5-lite/default/lite/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-lite/default/lite/1.md
@@ -5,7 +5,7 @@ TF Lite version of the YOLO model (with DarkNet 53 backbone) trained on the CPPE
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/lite/model.tflite -->
 
 ### Overview
-The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/yolo-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-lite/fp16/lite/1.md
@@ -5,7 +5,7 @@ TF Lite quantized version of the YOLO model (with DarkNet 53 backbone) trained o
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/lite/model_f16.tflite -->
 
 ### Overview
-The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/yolo-cppe5-lite/fp16/lite/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-lite/fp16/lite/1.md
@@ -1,0 +1,28 @@
+# Lite rishit-dagli/yolo-cppe5-lite/fp16/1
+TF Lite quantized version of the YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/yolo-cppe5-lite/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/lite/model_f16.tflite -->
+
+### Overview
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Note
+
+- This model was quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TF Lite converter API](https://www.tensorflow.org/lite/convert).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Redmon, Joseph, and Ali Farhadi. "Yolov3: An incremental improvement." arXiv preprint arXiv:1804.02767 (2018).
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/1.md
@@ -1,0 +1,8 @@
+# Placeholder rishit-dagli/yolo-cppe5-tfjs/1
+The YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset in TFJS Format.
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: yolo -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/default/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/yolo-cppe5-tfjs/default/1
+TFJS version of the YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/yolo-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tfjs/yolo_tfjs.tar.gz -->
+
+### Overview
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/yolo-cppe5/default/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was _not_ quantized.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Redmon, Joseph, and Ali Farhadi. "Yolov3: An incremental improvement." arXiv preprint arXiv:1804.02767 (2018).
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/default/tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/default/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS version of the YOLO model (with DarkNet 53 backbone) trained on the CPPE - 
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tfjs/yolo_tfjs.tar.gz -->
 
 ### Overview
-The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/fp16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS FP16 quantized version of the YOLO model (with DarkNet 53 backbone) trained
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tfjs/yolo_fp16.tar.gz -->
 
 ### Overview
-The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/fp16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/fp16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/yolo-cppe5-tfjs/fp16/1
+TFJS FP16 quantized version of the YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/yolo-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tfjs/yolo_fp16.tar.gz -->
+
+### Overview
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/yolo-cppe5-tfjs/fp16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `float16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Redmon, Joseph, and Ali Farhadi. "Yolov3: An incremental improvement." arXiv preprint arXiv:1804.02767 (2018).
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/uint16/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint16 quantized version of the YOLO model (with DarkNet 53 backbone) train
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tfjs/yolo_uint8.tar.gz -->
 
 ### Overview
-The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/uint16/tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/uint16/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/yolo-cppe5-tfjs/uint16/1
+TFJS uint16 quantized version of the YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/yolo-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tfjs/yolo_uint8.tar.gz -->
+
+### Overview
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/yolo-cppe5-tfjs/uint16/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint16` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Redmon, Joseph, and Ali Farhadi. "Yolov3: An incremental improvement." arXiv preprint arXiv:1804.02767 (2018).
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/uint8/tfjs/1.md
@@ -1,0 +1,47 @@
+# Tfjs rishit-dagli/yolo-cppe5-tfjs/uint8/1
+TFJS uint8 quantized version of the YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- parent-model: rishit-dagli/yolo-cppe5-tfjs/1 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tfjs/yolo_uint8.tar.gz -->
+
+### Overview
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Usage
+The saved model can be loaded directly:
+
+```js
+const model = await tf.loadGraphModel("https://tfhub.dev/rishit-dagli/yolo-cppe5-tfjs/uint8/tfjs/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+### Note
+
+- This model was quantized using `uint8` quantization.
+- This model takes fixed-shaped (800 x 1216) inputs.
+- This model has been converted using the [TensorFlow.js converter API](https://www.tensorflow.org/js/guide/conversion).
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Redmon, Joseph, and Ali Farhadi. "Yolov3: An incremental improvement." arXiv preprint arXiv:1804.02767 (2018).
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/assets/docs/rishit-dagli/yolo-cppe5-tfjs/uint8/tfjs/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5-tfjs/uint8/tfjs/1.md
@@ -5,7 +5,7 @@ TFJS uint8 quantized version of the YOLO model (with DarkNet 53 backbone) traine
 <!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tfjs/yolo_uint8.tar.gz -->
 
 ### Overview
-The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/yolo-cppe5/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5/1.md
@@ -14,7 +14,7 @@ The YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Perso
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
 ### Overview
-The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
 
 We include the training code as well some tools for this model in our paper GitHub repository [3].
 

--- a/assets/docs/rishit-dagli/yolo-cppe5/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5/1.md
@@ -8,7 +8,7 @@ The YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Perso
 <!-- fine-tunable: false -->
 <!-- license: apache-2.0 -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tf_yolo.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/yolo.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/yolo-cppe5/1.md
+++ b/assets/docs/rishit-dagli/yolo-cppe5/1.md
@@ -1,0 +1,72 @@
+# Module rishit-dagli/yolo-cppe5/1
+
+The YOLO model (with DarkNet 53 backbone) trained on the CPPE - 5 (Medical Personal Protective Equipment) dataset [1].
+
+<!-- task: image-object-detection -->
+<!-- network-architecture: yolo -->
+<!-- dataset: cppe-5 -->
+<!-- fine-tunable: false -->
+<!-- license: apache-2.0 -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/cppe-5/trained_models/yolo/tf_yolo.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+The YOLO model was proposed by Redmon et al. in their paper "Yolov3: An incremental improvement" [2]. The YOLO model is trained on the CPPE - 5 dataset we present in our paper "CPPE - 5: Medical Personal Protective Equipment Dataset" [1] which is a new challenging dataset with an aim to facilitate the study of subordinate categorization of medical personal protective equipments. This dataset mostly contains non-iconic images or or non-canonical perspectives in their natural context. This allows models to be better at generalizing, being easily deployable to real-world scenarios and often contain other objects in an image as well.
+
+We include the training code as well some tools for this model in our paper GitHub repository [3].
+
+### Model Performance
+Here we present the performance of the YOLO model on the CPPE - 5 dataset. For evaluation, we adopt the metrics from the COCO detection evaluation criteria, including the mean Average Precision (AP) across IoU thresholds ranging from 0.50 to 0.95 at different scales.
+
+|   Method    | AP<sup>box</sup> | AP<sub>50</sub><sup>box</sup> | AP<sub>75</sub><sup>box</sup> | AP<sub>S</sub><sup>box</sup> | AP<sub>M</sub><sup>box</sup> | AP<sub>L</sub><sup>box</sup> |
+| :---------: | :--------------: | :---------------------------: | :---------------------------: | :--------------------------: | :--------------------------: | :--------------------------: |
+| YOLO | 38.5            |                  79.4                   |                  35.3                   |                   23.1                   |                   28.4                   |                   49.0                   |
+
+### Usage
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/yolo-cppe5/1")
+```
+
+The inputs to the models should:
+
+- have color values in the range `[0,1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions
+- the expected size of the input images is height x width = 800 x 1216 pixels
+- the images should in the `channels_first` format
+- The shape of the input tensor would ths be `(1, 3, 800, 1216)`, the first dimension represents the batch size
+
+The model outputs are:
+
+- `outputs['dets']`: A tensor of shape `[batch_size, 100, 5]` with the bounding boxes in normalized coordinates.
+- `outputs['labels']`: A tensor of shape `[batch_size, 100]` with the class labels for the bounding boxes.
+
+It can also be used within a KerasLayer:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/yolo-cppe5/1")
+```
+
+### Model Complexity
+We measure the model complexity in terms of the number of parameters FLOPS and FPS. The inference speed FPS (Frames per second) for detector is measured on a machine with 1 Tesla V100 GPU.
+
+|          Method           |      AP<sup>box</sup>      | #Params  |   FLOPs   | FPS  |
+|:-------------------------:|:--------------------------:|:--------:|:---------:|:----:|
+|           YOLO            |            44.4            | 61.55 M  | 193.93 G  | 48.1 |
+
+### Acknowledgements
+
+This is joint work with Ali Mustufa Shaikh. The authors would like to thank Google for supporting this work by providing Google Cloud credits. The authors would also like to thank [Google TPU Research Cloud (TRC) program](https://sites.research.google/trc) for providing access to TPUs.
+
+### References
+
+[1] Dagli, Rishit, and Ali Mustufa Shaikh. ‘CPPE-5: Medical Personal Protective Equipment Dataset’. ArXiv:2112.09569 [Cs], Dec. 2021. arXiv.org, http://arxiv.org/abs/2112.09569.
+
+[2] Redmon, Joseph, and Ali Farhadi. "Yolov3: An incremental improvement." arXiv preprint arXiv:1804.02767 (2018).
+
+[3] https://github.com/Rishit-dagli/CPPE-Dataset

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -227,3 +227,5 @@ values:
     display_name: FCOS
   - id: fsaf
     display_name: FSAF
+  - id: regnetx
+    display_name: RegNetX

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -229,3 +229,5 @@ values:
     display_name: FSAF
   - id: regnetx
     display_name: RegNetX
+  - id: yolo
+    display_name: YOLO

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -223,3 +223,5 @@ values:
     display_name: Transformer iN Transformer
   - id: tridentnet
     display_name: TridentNet
+  - id: fcos
+    display_name: FCOS

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -225,3 +225,5 @@ values:
     display_name: TridentNet
   - id: fcos
     display_name: FCOS
+  - id: fsaf
+    display_name: FSAF


### PR DESCRIPTION
Following the previous PRs in this PR I add the following models:

- SSD
- YOLO
- FCOS
- FSAF
- RegNet

PS: A feature request for the FCOS models is still open on tensorflow/models (https://github.com/tensorflow/models/issues/10275) 

---
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
