### PR TITLE
Fix image links in my example code

### DIFF
--- a/assets/docs/rishit-dagli/convmixer-1024-20/1.md
+++ b/assets/docs/rishit-dagli/convmixer-1024-20/1.md
@@ -91,7 +91,7 @@ def infer_on_image(img_url, expected_label, model):
 
 
 infer_on_image(
-    img_url="https://i.imgur.com/A5m4ZG1.jpg", expected_label="scorpion", model=model
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", expected_label="scorpion", model=model
 )
 ```
 

--- a/assets/docs/rishit-dagli/convmixer-1536-20/1.md
+++ b/assets/docs/rishit-dagli/convmixer-1536-20/1.md
@@ -91,7 +91,7 @@ def infer_on_image(img_url, expected_label, model):
 
 
 infer_on_image(
-    img_url="https://i.imgur.com/A5m4ZG1.jpg", expected_label="scorpion", model=model
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", expected_label="scorpion", model=model
 )
 ```
 

--- a/assets/docs/rishit-dagli/convmixer-768-32/1.md
+++ b/assets/docs/rishit-dagli/convmixer-768-32/1.md
@@ -91,7 +91,7 @@ def infer_on_image(img_url, expected_label, model):
 
 
 infer_on_image(
-    img_url="https://i.imgur.com/A5m4ZG1.jpg", expected_label="scorpion", model=model
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", expected_label="scorpion", model=model
 )
 ```
 

--- a/assets/docs/rishit-dagli/tnt-s/1.md
+++ b/assets/docs/rishit-dagli/tnt-s/1.md
@@ -9,7 +9,7 @@ The Transformer iN Transformer (TNT) model uses pixel level attention paired wit
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
 <!-- asset-path: https://storage.googleapis.com/rishit-dagli.appspot.com/tnt_s_patch16_224.tar.gz -->
-<!-- colab: https://colab.research.google.com/github/Rishit-dagli/ConvMixer-torch2tf/blob/main/classification.ipynb -->
+<!-- colab: https://colab.research.google.com/github/Rishit-dagli/Transformer-in-Transformer/blob/main/example/pre_trained_model.ipynb -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
@@ -55,9 +55,11 @@ import numpy as np
 import requests
 import tensorflow as tf
 import tensorflow_hub as hub
-from PIL import image
+from PIL import Image
 
 model = hub.load("https://tfhub.dev/rishit-dagli/tnt-s/1")
+
+resolution = [224, 224]
 
 
 def preprocess_image(image):
@@ -94,10 +96,14 @@ def infer_on_image(img_url, expected_label, model):
 
 
 infer_on_image(
-    img_url="https://i.imgur.com/NFsafX4.jpg", expected_label="tench, Tinca_tinca"
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/gW4Gh5v.jpg",
+    expected_label="tench, Tinca_tinca",
+    model=model,
 )
 infer_on_image(
-    img_url="https://i.imgur.com/Wv99De3.jpg", expected_label="window_screen"
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/Wv99De3.jpg",
+    expected_label="window_screen",
+    model=model,
 )
 ```
 


### PR DESCRIPTION
The example code I share in the documentation for 4 of my models used Imgur links to host the image, these demos have suddenly stopped working and throw the error:

> UnidentifiedImageError: cannot identify image file <_io.BytesIO object at ... >

I tried multiple things including changing `Pillow` versions and it seems the error stems due to Imgur blocking image downloads on Google Colab in this way. In this PR I changed the image links I show in the example code and the Colab Notebooks I link in the documentation to the same images but now downloaded from my GCS bucket which does the work.

Affected Model documentations:

- https://tfhub.dev/rishit-dagli/convmixer-1536-20/1
- https://tfhub.dev/rishit-dagli/convmixer-768-32/1
- https://tfhub.dev/rishit-dagli/convmixer-1024-20/1
- https://tfhub.dev/rishit-dagli/tnt-s/1

---
Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
