### PR TITLE
Open-source models for IREE benchmarking

### DIFF
--- a/assets/docs/iree/iree.md
+++ b/assets/docs/iree/iree.md
@@ -1,0 +1,13 @@
+# Publisher iree
+
+IREE
+
+[![Icon URL]](https://google.github.io/iree/ghost.svg)
+
+## [https://google.github.io/iree/](https://google.github.io/iree/)
+
+IREE (Intermediate Representation Execution Environment1) is an MLIR-based
+end-to-end compiler and runtime that lowers Machine Learning (ML) models to a
+unified IR that scales up to meet the needs of the datacenter and down to
+satisfy the constraints and special considerations of mobile and edge
+deployments.

--- a/assets/docs/iree/models/mobilebert/fp32/1.md
+++ b/assets/docs/iree/models/mobilebert/fp32/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/mobilebert/fp32/1
+
+MobileBert trained on Squad 1.1
+
+<!-- task: text-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilebert -->
+<!-- dataset: squad -->
+
+## Overview
+
+MobileBert trained on Squad 1.1 in `fp32`.
+
+### References
+Zhiqing Sun, Hongkun Yu, Xiaodan Song, Renjie Liu, Yiming Yang, & Denny Zhou (2020). MobileBERT: a Compact Task-Agnostic BERT for Resource-Limited Devices. CoRR, abs/2004.02984.

--- a/assets/docs/iree/models/mobilebert/fp32/lite/1.md
+++ b/assets/docs/iree/models/mobilebert/fp32/lite/1.md
@@ -1,0 +1,19 @@
+# Lite iree/mobilebert/fp32/1
+
+A deployment format of iree/mobilebert/fp32
+
+<!-- parent-model: iree/mobilebert/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilebert/fp32/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `fp32` inference.
+
+### Input
+* `serving_default_input_word_ids:0`: an `int32` array of size `[1, 384]` containing tokenized ids of input text.
+* `serving_default_input_type_ids:0`: an `int32` array of size `[1, 384]` containing segment ids, where `0` represents the first sequence and `1` for the second sequence.
+* `serving_default_input_mask:0`: an `int32` array of size `[1, 384]` containing a mask where `0` represents padding tokens and `1` represents real tokens.
+
+### Output
+* `StatefulPartitionedCall:0`: an `fp32` array of size `[1, 384]` containing logits over the sequence indicating the end position of the answer span with closed interval.
+* `StatefulPartitionedCall:1`: an `fp32` array of size `[1, 384]` containing logits over the sequence indicating the start position of the answer span with closed interval.

--- a/assets/docs/iree/models/mobilebert/int8/1.md
+++ b/assets/docs/iree/models/mobilebert/int8/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/mobilebert/int8/1
+
+MobileBert trained on Squad 1.1 and quantized using post-training quantization.
+
+<!-- task: text-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilebert -->
+<!-- dataset: squad -->
+
+## Overview
+
+MobileBert trained on Squad 1.1 in `int8`.
+
+### References
+Zhiqing Sun, Hongkun Yu, Xiaodan Song, Renjie Liu, Yiming Yang, & Denny Zhou (2020). MobileBERT: a Compact Task-Agnostic BERT for Resource-Limited Devices. CoRR, abs/2004.02984.

--- a/assets/docs/iree/models/mobilebert/int8/lite/1.md
+++ b/assets/docs/iree/models/mobilebert/int8/lite/1.md
@@ -1,0 +1,19 @@
+# Lite iree/mobilebert/int8/1
+
+A deployment format of iree/mobilebert/int8
+
+<!-- parent-model: iree/mobilebert/int8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilebert/int8/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `fp32` inference.
+
+### Input
+* `serving_default_input_word_ids:0`: an `int32` array of size `[1, 384]` containing tokenized ids of input text.
+* `serving_default_input_type_ids:0`: an `int32` array of size `[1, 384]` containing segment ids, where `0` represents the first sequence and `1` for the second sequence.
+* `serving_default_input_mask:0`: an `int32` array of size `[1, 384]` containing a mask where `0` represents padding tokens and `1` represents real tokens.
+
+### Output
+* `StatefulPartitionedCall:0`: an `fp32` array of size `[1, 384]` containing logits over the sequence indicating the end position of the answer span with closed interval.
+* `StatefulPartitionedCall:1`: an `fp32` array of size `[1, 384]` containing logits over the sequence indicating the start position of the answer span with closed interval.

--- a/assets/docs/iree/models/mobilebert_edgetpu_s/fp32/1.md
+++ b/assets/docs/iree/models/mobilebert_edgetpu_s/fp32/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/mobilebert_edgetpu_s/fp32/1
+
+MobileBert EdgeTPU Small trained on Squad 1.1
+
+<!-- task: text-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilebert-edgetpu-s -->
+<!-- dataset: squad -->
+
+## Overview
+
+MobileBert EdgeTPU Small trained on Squad 1.1 in `fp32`.
+
+### References
+https://tfhub.dev/google/collections/mobilebert-edgetpu/1

--- a/assets/docs/iree/models/mobilebert_edgetpu_s/fp32/lite/1.md
+++ b/assets/docs/iree/models/mobilebert_edgetpu_s/fp32/lite/1.md
@@ -1,0 +1,19 @@
+# Lite iree/mobilebert_edgetpu_s/fp32/1
+
+A deployment format of iree/mobilebert_edgetpu_s/fp32
+
+<!-- parent-model: iree/mobilebert_edgetpu_s/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilebert_edgetpu_s/fp32/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `fp32` inference.
+
+### Input
+* `serving_default_input_word_ids:0`: an `int32` array of size `[1, 384]` containing tokenized ids of input text.
+* `serving_default_input_type_ids:0`: an `int32` array of size `[1, 384]` containing segment ids, where `0` represents the first sequence and `1` for the second sequence.
+* `serving_default_input_mask:0`: an `int32` array of size `[1, 384]` containing a mask where `0` represents padding tokens and `1` represents real tokens.
+
+### Output
+* `StatefulPartitionedCall:0`: an `fp32` array of size `[1, 384]` containing logits over the sequence indicating the end position of the answer span with closed interval.
+* `StatefulPartitionedCall:1`: an `fp32` array of size `[1, 384]` containing logits over the sequence indicating the start position of the answer span with closed interval.

--- a/assets/docs/iree/models/mobilebert_edgetpu_s/int8/1.md
+++ b/assets/docs/iree/models/mobilebert_edgetpu_s/int8/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/mobilebert_edgetpu_s/int8/1
+
+MobileBert EdgeTPU Small trained on Squad 1.1
+
+<!-- task: text-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilebert-edgetpu-s -->
+<!-- dataset: squad -->
+
+## Overview
+
+MobileBert EdgeTPU Small trained on Squad 1.1 in `int8`.
+
+### References
+https://tfhub.dev/google/collections/mobilebert-edgetpu/1

--- a/assets/docs/iree/models/mobilebert_edgetpu_s/int8/lite/1.md
+++ b/assets/docs/iree/models/mobilebert_edgetpu_s/int8/lite/1.md
@@ -1,0 +1,19 @@
+# Lite iree/mobilebert_edgetpu_s/int8/1
+
+A deployment format of iree/mobilebert_edgetpu_s/int8
+
+<!-- parent-model: iree/mobilebert_edgetpu_s/int8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilebert_edgetpu_s/int8/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `fp32` inference.
+
+### Input
+* `serving_default_input_word_ids:0`: an `int32` array of size `[1, 384]` containing tokenized ids of input text.
+* `serving_default_input_type_ids:0`: an `int32` array of size `[1, 384]` containing segment ids, where `0` represents the first sequence and `1` for the second sequence.
+* `serving_default_input_mask:0`: an `int32` array of size `[1, 384]` containing a mask where `0` represents padding tokens and `1` represents real tokens.
+
+### Output
+* `StatefulPartitionedCall:0`: an `fp32` array of size `[1, 384]` containing logits over the sequence indicating the end position of the answer span with closed interval.
+* `StatefulPartitionedCall:1`: an `fp32` array of size `[1, 384]` containing logits over the sequence indicating the start position of the answer span with closed interval.

--- a/assets/docs/iree/models/mobilenet_v1_100_224/fp32/1.md
+++ b/assets/docs/iree/models/mobilenet_v1_100_224/fp32/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/mobilenet_v1_100_224/fp32/1
+
+Mobilenet V1 trained on Imagenet.
+
+<!-- task: image-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilenet-v1 -->
+<!-- dataset: imagenet -->
+
+## Overview
+
+Mobilenet V1 trained on Imagenet in `fp32`.
+
+### References
+Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko, Weijun Wang, Tobias Weyand, Marco Andreetto, & Hartwig Adam (2017). MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications. CoRR, abs/1704.04861.

--- a/assets/docs/iree/models/mobilenet_v1_100_224/fp32/lite/1.md
+++ b/assets/docs/iree/models/mobilenet_v1_100_224/fp32/lite/1.md
@@ -1,0 +1,20 @@
+# Lite iree/mobilenet_v1_100_224/fp32/1
+
+A deployment format of iree/mobilenet_v1_100_224/fp32
+
+<!-- parent-model: iree/mobilenet_v1_100_224/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilenet_v1_100_224/fp32/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `fp32` inference. Achieves 72.5% accuracy on Imagenet.
+
+### Input
+
+Input buffer of size `[batch, height, width, channels]` where `batch = 1`,
+`height = 224`, `width = 224`, `channels = 3` i.e. `[1, 224, 224, 3]` in `fp32`. Values should be normalized to `[-1, 1]`.
+
+### Output
+
+Probability, a float array of size `[1][NUM_CLASS]`, where `NUM_CLASS = 1001` is
+the number of classes.

--- a/assets/docs/iree/models/mobilenet_v1_100_224/uint8/1.md
+++ b/assets/docs/iree/models/mobilenet_v1_100_224/uint8/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/mobilenet_v1_100_224/uint8/1
+
+Mobilenet V1 trained on Imagenet.
+
+<!-- task: image-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilenet-v1 -->
+<!-- dataset: imagenet -->
+
+## Overview
+
+Mobilenet V1 trained on Imagenet in `uint8`.
+
+### References
+Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko, Weijun Wang, Tobias Weyand, Marco Andreetto, & Hartwig Adam (2017). MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications. CoRR, abs/1704.04861.

--- a/assets/docs/iree/models/mobilenet_v1_100_224/uint8/lite/1.md
+++ b/assets/docs/iree/models/mobilenet_v1_100_224/uint8/lite/1.md
@@ -1,0 +1,22 @@
+# Lite iree/mobilenet_v1_100_224/uint8/1
+
+A deployment format of iree/mobilenet_v1_100_224/uint8
+
+<!-- parent-model: iree/mobilenet_v1_100_224/uint8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilenet_v1_100_224/uint8/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `uint8` inference, using quantization-aware
+training. Achieves 71.8% on Imagenet.
+
+### Input
+
+Input buffer of size `[batch, height, width, channels]` where `batch = 1`,
+`height = 224`, `width = 224`, `channels = 3` i.e. `[1, 224, 224, 3]` in uint8.
+Values should be between `[0, 255]`.
+
+### Output
+
+Probability, a `uint8` array of size `[1][NUM_CLASS]`, where `NUM_CLASS = 1001` is
+the number of classes.

--- a/assets/docs/iree/models/mobilenet_v2_100_224/fp32/1.md
+++ b/assets/docs/iree/models/mobilenet_v2_100_224/fp32/1.md
@@ -1,0 +1,18 @@
+# Placeholder iree/mobilenet_v2_100_224/fp32/1
+
+Mobilenet V2 trained on Imagenet.
+
+<!-- task: image-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilenet-v2 -->
+<!-- dataset: imagenet -->
+
+## Overview
+
+Mobilenet V2 trained on Imagenet in `fp32`.
+
+### References
+Mark Sandler, Andrew G. Howard, Menglong Zhu, Andrey Zhmoginov, & Liang-Chieh Chen (2018). Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification, Detection and Segmentation. CoRR, abs/1801.04381.
+
+

--- a/assets/docs/iree/models/mobilenet_v2_100_224/fp32/lite/1.md
+++ b/assets/docs/iree/models/mobilenet_v2_100_224/fp32/lite/1.md
@@ -1,0 +1,21 @@
+# Lite iree/mobilenet_v2_100_224/fp32/1
+
+A deployment format of iree/mobilenet_v2_100_224/fp32
+
+<!-- parent-model: iree/mobilenet_v2_100_224/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilenet_v2_100_224/fp32/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `fp32` inference. Achieves 72.5%
+accuracy on Imagenet.
+
+### Input
+
+Input buffer of size `[batch, height, width, channels]` where `batch = 1`,
+`height = 224`, `width = 224`, `channels = 3` i.e. `[1, 224, 224, 3]` in `fp32`. Values should be normalized to `[-1, 1]`.
+
+### Output
+
+Probability, a float array of size `[1][NUM_CLASS]`, where `NUM_CLASS = 1001` is
+the number of classes.

--- a/assets/docs/iree/models/mobilenet_v2_100_224/uint8/1.md
+++ b/assets/docs/iree/models/mobilenet_v2_100_224/uint8/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/mobilenet_v2_100_224/uint8/1
+
+Mobilenet V2 trained on Imagenet.
+
+<!-- task: image-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilenet-v2 -->
+<!-- dataset: imagenet -->
+
+## Overview
+
+Mobilenet V2 trained on Imagenet in `uint8`.
+
+### References
+Mark Sandler, Andrew G. Howard, Menglong Zhu, Andrey Zhmoginov, & Liang-Chieh Chen (2018). Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification, Detection and Segmentation. CoRR, abs/1801.04381.

--- a/assets/docs/iree/models/mobilenet_v2_100_224/uint8/lite/1.md
+++ b/assets/docs/iree/models/mobilenet_v2_100_224/uint8/lite/1.md
@@ -1,0 +1,22 @@
+# Lite iree/mobilenet_v2_100_224/uint8/1
+
+A deployment format of iree/mobilenet_v2_100_224/uint8
+
+<!-- parent-model: iree/mobilenet_v2_100_224/uint8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilenet_v2_100_224/uint8/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `uint8` inference, using quantization-aware
+training. Achieves 72.6% on Imagenet.
+
+### Input
+
+Input buffer of size `[batch, height, width, channels]` where `batch = 1`,
+`height = 224`, `width = 224`, `channels = 3` i.e. `[1, 224, 224, 3]` in uint8.
+Values should be between `[0, 255]`.
+
+### Output
+
+Probability, a `uint8` array of size `[1][NUM_CLASS]`, where `NUM_CLASS = 1001` is
+the number of classes.

--- a/assets/docs/iree/models/mobilenet_v3_large_100_224/fp32/1.md
+++ b/assets/docs/iree/models/mobilenet_v3_large_100_224/fp32/1.md
@@ -1,0 +1,18 @@
+# Placeholder iree/mobilenet_v3_large_100_224/fp32/1
+
+Mobilenet V3 trained on Imagenet.
+
+<!-- task: image-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilenet-v3 -->
+<!-- dataset: imagenet -->
+
+## Overview
+
+Mobilenet V3 trained on Imagenet in `fp32`.
+
+### References
+Andrew Howard, Mark Sandler, Grace Chu, Liang-Chieh Chen, Bo Chen, Mingxing Tan, Weijun Wang, Yukun Zhu, Ruoming Pang, Vijay Vasudevan, Quoc V. Le, & Hartwig Adam (2019). Searching for MobileNetV3. CoRR, abs/1905.02244.
+
+

--- a/assets/docs/iree/models/mobilenet_v3_large_100_224/fp32/lite/1.md
+++ b/assets/docs/iree/models/mobilenet_v3_large_100_224/fp32/lite/1.md
@@ -1,0 +1,22 @@
+# Lite iree/mobilenet_v3_large_100_224/fp32/1
+
+A deployment format of iree/mobilenet_v3_large_100_224/fp32
+
+<!-- parent-model: iree/mobilenet_v3_large_100_224/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilenet_v3_large_100_224/fp32/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `fp32` inference. Achieves 73.5%
+accuracy on Imagenet.
+
+### Input
+
+Input buffer of size `[batch, height, width, channels]` where `batch = 1`,
+`height = 224`, `width = 224`, `channels = 3` i.e. `[1, 224, 224, 3]` in 32-bit
+floating point. Values should be normalized to `[-1, 1]`.
+
+### Output
+
+Probability, a float array of size `[1][NUM_CLASS]`, where `NUM_CLASS = 1001` is
+the number of classes.

--- a/assets/docs/iree/models/mobilenet_v3_large_100_224/uint8/1.md
+++ b/assets/docs/iree/models/mobilenet_v3_large_100_224/uint8/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/mobilenet_v3_large_100_224/uint8/1
+
+Mobilenet V3 trained on Imagenet.
+
+<!-- task: image-classification -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: mobilenet-v3 -->
+<!-- dataset: imagenet -->
+
+## Overview
+
+Mobilenet V3 trained on Imagenet in `uint8`.
+
+### References
+Andrew Howard, Mark Sandler, Grace Chu, Liang-Chieh Chen, Bo Chen, Mingxing Tan, Weijun Wang, Yukun Zhu, Ruoming Pang, Vijay Vasudevan, Quoc V. Le, & Hartwig Adam (2019). Searching for MobileNetV3. CoRR, abs/1905.02244.

--- a/assets/docs/iree/models/mobilenet_v3_large_100_224/uint8/lite/1.md
+++ b/assets/docs/iree/models/mobilenet_v3_large_100_224/uint8/lite/1.md
@@ -1,0 +1,22 @@
+# Lite iree/mobilenet_v3_large_100_224/uint8/1
+
+A deployment format of iree/mobilenet_v3_large_100_224/uint8
+
+<!-- parent-model: iree/mobilenet_v3_large_100_224/uint8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/mobilenet_v3_100_224/uint8/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for `uint8` inference, using quantization-aware
+training. Achieves 72.7% on Imagenet.
+
+### Input
+
+Input buffer of size `[batch, height, width, channels]` where `batch = 1`,
+`height = 224`, `width = 224`, `channels = 3` i.e. `[1, 224, 224, 3]` in uint8.
+Values should be between `[0, 255]`.
+
+### Output
+
+Probability, a `uint8` array of size `[1][NUM_CLASS]`, where `NUM_CLASS = 1001` is
+the number of classes.

--- a/assets/docs/iree/models/ssd_mobilenet_v1_100_320/fp32/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v1_100_320/fp32/1.md
@@ -1,0 +1,18 @@
+# Placeholder iree/ssd_mobilenet_v1_100_320/fp32/1
+
+Mobilenet V1 with SSDLite head trained on COCO 2017, in `fp32`.
+
+<!-- task: image-object-detection -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: ssd-mobilenet-v1 -->
+<!-- dataset: coco-2017 -->
+
+## Overview
+
+Mobilenet V1 with SSDLite head trained on COCO 2017, in `fp32`. Achieves 23% mAP
+on COCO 2017.
+
+### References
+1. Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko, Weijun Wang, Tobias Weyand, Marco Andreetto, & Hartwig Adam (2017). MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications. CoRR, abs/1704.04861.
+2. Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott E. Reed, Cheng-Yang Fu, & Alexander C. Berg (2015). SSD: Single Shot MultiBox Detector. CoRR, abs/1512.02325.

--- a/assets/docs/iree/models/ssd_mobilenet_v1_100_320/fp32/default/lite/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v1_100_320/fp32/default/lite/1.md
@@ -1,0 +1,32 @@
+# Lite iree/ssd_mobilenet_v1_100_320/fp32/default/1
+
+A deployment format of iree/ssd_mobilenet_v1_100_320/fp32
+
+<!-- parent-model: iree/ssd_mobilenet_v1_100_320/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_mobilenet_v1_100_320/fp32/default/1.tflite -->
+
+## Overview
+
+Model is in TFLite format for 32-bit floating-point inference. Achieves 23% mAP
+on COCO 2017.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `height = 320`, `width = 320`,
+    `channels = 3` i.e. `[1, 320, 320, 3]`. Values should be normalized to `[-1,
+    1]`.
+
+### Output
+*   `raw_outputs/box_encodings`: an `fp32` array of shape `[1, M, 4]` containing
+    decoded detection boxes without Non-Max suppression. `M` is the number of
+    raw detections.
+*   `raw_outputs/class_predictions`: a `fp32` array of shape `[1, M, 91]` and
+    contains class probabilities for raw detection boxes. `M` is the number of
+    raw detections.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph.pb`: the frozen Tensorflow graph with `anchors` included as a constant tensor.
+* `ssd_mobilenet_v1_coco.tflite`: the converted TFLite file with raw outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_mobilenet_v1_100_320/fp32/nms/lite/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v1_100_320/fp32/nms/lite/1.md
@@ -1,0 +1,34 @@
+# Lite iree/ssd_mobilenet_v1_100_320/fp32/nms/1
+
+A deployment format of iree/ssd_mobilenet_v1_100_320/fp32
+
+<!-- parent-model: iree/ssd_mobilenet_v1_100_320/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_mobilenet_v1_100_320/fp32/nms/1.tflite -->
+
+## Overview
+Model is in TFLite format for 32-bit floating-point inference. Achieves 23% mAP
+on COCO 2017.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `height = 320`, `width = 320`,
+    `channels = 3` i.e. `[1, 320, 320, 3]`. Values should be normalized to `[-1,
+    1]`.
+
+### Output
+*   `TFLite_Detection_PostProcess`: The detection boxes. An `fp32` array of
+    shape `[N, 4]` containing bounding box coordinates in the following order:
+    `[ymin, xmin, ymax, xmax]`.
+*   `TFLite_Detection_PostProcess:1`: The detection classes. An `fp32` array of
+    shape `[N]` containing detection class index from the label file.
+*   `TFLite_Detection_PostProcess:2`: The detection class scores. An `fp32`
+    array of shape `[N]` containing detection scores.
+*   `TFLite_Detection_PostProcess:3`: The number of detections `N`. A single
+    `fp32` value.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph_pp.pb`: the frozen Tensorflow graph with `TFLite_Detection_PostProcess` op attached.
+* `ssd_mobilenet_v1_coco_nms.tflite`: the converted TFLite file with processed outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_mobilenet_v1_100_320/uint8/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v1_100_320/uint8/1.md
@@ -1,0 +1,18 @@
+# Placeholder iree/ssd_mobilenet_v1_100_320/uint8/1
+
+Mobilenet V1 with SSDLite head trained on COCO 2017, in `uint8`.
+
+<!-- task: image-object-detection -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: ssd-mobilenet-v1 -->
+<!-- dataset: coco-2017 -->
+
+## Overview
+
+Mobilenet V1 with SSDLite head trained on COCO 2017, in `uint8`. Achieves 22.5% mAP
+on COCO 2017.
+
+### References
+1. Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko, Weijun Wang, Tobias Weyand, Marco Andreetto, & Hartwig Adam (2017). MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications. CoRR, abs/1704.04861.
+2. Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott E. Reed, Cheng-Yang Fu, & Alexander C. Berg (2015). SSD: Single Shot MultiBox Detector. CoRR, abs/1512.02325.

--- a/assets/docs/iree/models/ssd_mobilenet_v1_100_320/uint8/default/lite/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v1_100_320/uint8/default/lite/1.md
@@ -1,0 +1,27 @@
+# Lite iree/ssd_mobilenet_v1_100_320/uint8/default/1
+
+A deployment format of iree/ssd_mobilenet_v1_100_320/uint8
+
+<!-- parent-model: iree/ssd_mobilenet_v1_100_320/uint8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_mobilenet_v1_100_320/uint8/default/1.tflite -->
+
+## Overview
+Model is in TFLite format for `uint8` inference. Achieves 22.5% mAP
+on COCO 2017.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `height = 320`, `width = 320`,
+    `channels = 3` i.e. `[1, 320, 320, 3]`. Values should be between `[0, 255]`.
+
+### Output
+Outputs are the activations from the box predictors at each feature map in `uint8` and are of the form:
+* Box predictor: `[batch, height, width, box_encoding * num_anchors]`, where `batch=1`, `height` and `width` vary depending on the size of the feature map, `box_encoding` are the box coordinates at [`y_center`, `x_center`, `box_height`, `box_width`] and `num_anchors` is the number of anchors as defined in the anchor configuration.
+* Class predictor: `[batch, height, width, num_classes * num_anchors]`, where `batch=1`, `height` and `width` vary depending on the size of the feature map, `num_classes` is 91 (including background class), `num_anchors` is the number of anchors as defined in the anchor configuration.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph.pb`: the frozen Tensorflow graph with `anchors` included as a constant tensor.
+* `ssd_mobilenet_v1_quantized_coco.tflite`: the converted TFLite file with raw outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_mobilenet_v1_100_320/uint8/nms/lite/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v1_100_320/uint8/nms/lite/1.md
@@ -1,0 +1,34 @@
+# Lite iree/ssd_mobilenet_v1_100_320/uint8/nms/1
+
+A deployment format of iree/ssd_mobilenet_v1_100_320/uint8
+
+<!-- parent-model: iree/ssd_mobilenet_v1_100_320/uint8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_mobilenet_v1_100_320/uint8/nms/1.tflite -->
+
+## Overview
+Model is in TFLite format for `uint8` inference. Achieves 22.5% mAP
+on COCO 2017.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `height = 320`, `width = 320`,
+    `channels = 3` i.e. `[1, 320, 320, 3]`. Values should be normalized to `[-1,
+    1]`.
+
+### Output
+*   `TFLite_Detection_PostProcess`: The detection boxes. An `fp32` array of
+    shape `[N, 4]` containing bounding box coordinates in the following order:
+    `[ymin, xmin, ymax, xmax]`.
+*   `TFLite_Detection_PostProcess:1`: The detection classes. An `fp32` array of
+    shape `[N]` containing detection class index from the label file.
+*   `TFLite_Detection_PostProcess:2`: The detection class scores. An `fp32`
+    array of shape `[N]` containing detection scores.
+*   `TFLite_Detection_PostProcess:3`: The number of detections `N`. A single
+    `fp32` value.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph_pp.pb`: the frozen Tensorflow graph with `TFLite_Detection_PostProcess` op attached.
+* `ssd_mobilenet_v1_quantized_coco_nms.tflite`: the converted TFLite file with processed outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_mobilenet_v2_100/fp32/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v2_100/fp32/1.md
@@ -1,0 +1,20 @@
+# Placeholder iree/ssd_mobilenet_v2_100/fp32/1
+
+Mobilenet V2 with SSDLite head trained on COCO 2017, in `fp32`.
+
+<!-- task: image-object-detection -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: ssd-mobilenet-v1 -->
+<!-- dataset: coco-2017 -->
+
+## Overview
+
+Mobilenet V2 with SSDLite head trained on COCO 2017, in `fp32`. Works with dynamic width and height. Achieves 21.9% mAP
+on COCO 2017 at 320x320 input.
+
+### References
+1. Mark Sandler, Andrew G. Howard, Menglong Zhu, Andrey Zhmoginov, & Liang-Chieh Chen (2018). Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification, Detection and Segmentation. CoRR, abs/1801.04381.
+2. Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott E. Reed, Cheng-Yang Fu, & Alexander C. Berg (2015). SSD: Single Shot MultiBox Detector. CoRR, abs/1512.02325.
+3. Jonathan Long, Evan Shelhamer, & Trevor Darrell (2014). Fully Convolutional Networks for Semantic Segmentation. CoRR, abs/1411.4038.
+

--- a/assets/docs/iree/models/ssd_mobilenet_v2_100/fp32/default/lite/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v2_100/fp32/default/lite/1.md
@@ -1,0 +1,31 @@
+# Lite iree/ssd_mobilenet_v2_100/fp32/default/1
+
+A deployment format of iree/ssd_mobilenet_v2_100/fp32
+
+<!-- parent-model: iree/ssd_mobilenet_v2_100/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_mobilenet_v2_100/fp32/default/1.tflite -->
+
+## Overview
+
+Mobilenet V2 with SSDLite head trained on COCO 2017, in `fp32`. Works with dynamic width and height. Achieves 21.9% mAP
+on COCO 2017 at 320x320 input.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `channels = 3`, and `height` and `width` can be any size. Values should be normalized to `[-1,
+    1]`.
+
+### Output
+*   `raw_outputs/box_encodings`: an `fp32` array of shape `[1, M, 4]` containing
+    decoded detection boxes without Non-Max suppression. `M` is the number of
+    raw detections.
+*   `raw_outputs/class_predictions`: a `fp32` array of shape `[1, M, 91]` and
+    contains class logits for raw detection boxes. Score conversion layer not included. `M` is the number of
+    raw detections.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph.pb`: the frozen Tensorflow graph.
+* `ssd_mobilenet_v2.tflite`: the converted TFLite file with raw outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_mobilenet_v2_100/int8/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v2_100/int8/1.md
@@ -1,0 +1,19 @@
+# Placeholder iree/ssd_mobilenet_v2_100/int8/1
+
+Mobilenet V2 with SSDLite head trained on COCO 2017, in `int8`.
+
+<!-- task: image-object-detection -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: ssd-mobilenet-v1 -->
+<!-- dataset: coco-2017 -->
+
+## Overview
+
+Mobilenet V2 with SSDLite head trained on COCO 2017, in `int8`. Works with dynamic width and height. Achieves 21.2% mAP
+on COCO 2017 at 320x320 input.
+
+### References
+1. Mark Sandler, Andrew G. Howard, Menglong Zhu, Andrey Zhmoginov, & Liang-Chieh Chen (2018). Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification, Detection and Segmentation. CoRR, abs/1801.04381.
+2. Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott E. Reed, Cheng-Yang Fu, & Alexander C. Berg (2015). SSD: Single Shot MultiBox Detector. CoRR, abs/1512.02325.
+3. Jonathan Long, Evan Shelhamer, & Trevor Darrell (2014). Fully Convolutional Networks for Semantic Segmentation. CoRR, abs/1411.4038.

--- a/assets/docs/iree/models/ssd_mobilenet_v2_100/int8/default/lite/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v2_100/int8/default/lite/1.md
@@ -1,0 +1,27 @@
+# Lite iree/ssd_mobilenet_v2_100/int8/default/1
+
+A deployment format of iree/ssd_mobilenet_v2_100/int8
+
+<!-- parent-model: iree/ssd_mobilenet_v2_100/int8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_mobilenet_v2_100/int8/default/1.tflite -->
+
+## Overview
+
+Mobilenet V2 with SSDLite head trained on COCO 2017, in `int8`. Works with dynamic width and height. Achieves 21.2% mAP
+on COCO 2017 at 320x320 input.
+
+### Input
+*   `normalized_input_image_tensor`: an `int` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `channels = 3`, and `height` and `width` can be any size. Values should be between `[-128, 127]`.
+
+### Output
+Outputs are the activations from the box predictors at each feature map in `int8` and are of the form:
+* Box predictor: `[batch, height, width, box_encoding * num_anchors]`, where `batch=1`, `height` and `width` vary depending on the size of the feature map, `box_encoding` are the box coordinates at [`y_center`, `x_center`, `box_height`, `box_width`] and `num_anchors` is the number of anchors as defined in the anchor configuration.
+* Class predictor: `[batch, height, width, num_classes * num_anchors]`, where `batch=1`, `height` and `width` vary depending on the size of the feature map, `num_classes` is 91 (including background class), `num_anchors` is the number of anchors as defined in the anchor configuration.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph.pb`: the frozen Tensorflow graph.
+* `ssd_mobilenet_v2_int8.tflite`: the converted TFLite file with raw outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_mobilenet_v2_fpn_100/fp32/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v2_fpn_100/fp32/1.md
@@ -1,0 +1,21 @@
+# Placeholder iree/ssd_mobilenet_v2_fpn_100/fp32/1
+
+Mobilenet V2 with FPNLite head trained on COCO 2017, in `fp32`.
+
+<!-- task: image-object-detection -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: ssd-mobilenet-v2-fpn -->
+<!-- dataset: coco-2017 -->
+
+## Overview
+
+Mobilenet V2 with FPNLite head trained on COCO 2017, in `fp32`.. Works with dynamic width and height. Achieves 21.9% mAP
+on COCO 2017 at 320x320 input.
+
+### References
+1. Mark Sandler, Andrew G. Howard, Menglong Zhu, Andrey Zhmoginov, & Liang-Chieh Chen (2018). Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification, Detection and Segmentation. CoRR, abs/1801.04381.
+2. Tsung-Yi Lin, Piotr Dollár, Ross B. Girshick, Kaiming He, Bharath Hariharan, & Serge J. Belongie (2016). Feature Pyramid Networks for Object Detection. CoRR, abs/1612.03144.
+3. Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott E. Reed, Cheng-Yang Fu, & Alexander C. Berg (2015). SSD: Single Shot MultiBox Detector. CoRR, abs/1512.02325.
+4. Jonathan Long, Evan Shelhamer, & Trevor Darrell (2014). Fully Convolutional Networks for Semantic Segmentation. CoRR, abs/1411.4038.
+

--- a/assets/docs/iree/models/ssd_mobilenet_v2_fpn_100/fp32/default/lite/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v2_fpn_100/fp32/default/lite/1.md
@@ -1,0 +1,31 @@
+# Lite iree/ssd_mobilenet_v2_fpn_100/fp32/default/1
+
+A deployment format of iree/ssd_mobilenet_v2_fpn_100/fp32
+
+<!-- parent-model: iree/ssd_mobilenet_v2_fpn_100/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_mobilenet_v2_fpn_100/fp32/default/1.tflite -->
+
+## Overview
+
+Mobilenet V2 with FPNLite head trained on COCO 2017, in `fp32`. Works with dynamic width and height. Achieves 21.9% mAP
+on COCO 2017 at 320x320 input.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `channels = 3`, and `height` and `width` can be any size. Values should be normalized to `[-1,
+    1]`.
+
+### Output
+*   `raw_outputs/box_encodings`: an `fp32` array of shape `[1, M, 4]` containing
+    decoded detection boxes without Non-Max suppression. `M` is the number of
+    raw detections.
+*   `raw_outputs/class_predictions`: a `fp32` array of shape `[1, M, 91]` and
+    contains class logits for raw detection boxes. Score conversion layer not included. `M` is the number of
+    raw detections.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph.pb`: the frozen Tensorflow graph.
+* `ssd_mobilenet_v2_fpnlite.tflite`: the converted TFLite file with raw outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_mobilenet_v2_fpn_100/uint8/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v2_fpn_100/uint8/1.md
@@ -1,0 +1,21 @@
+# Placeholder iree/ssd_mobilenet_v2_fpn_100/uint8/1
+
+Mobilenet V2 with FPNLite head trained on COCO 2017, in `uint8`.
+
+<!-- task: image-object-detection -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: ssd-mobilenet-v2-fpn -->
+<!-- dataset: coco-2017 -->
+
+## Overview
+
+Mobilenet V2 with FPNLite head trained on COCO 2017, in `uint8`. Works with dynamic width and height. Achieves 20.6% mAP
+on COCO 2017 at 320x320 input.
+
+### References
+1. Mark Sandler, Andrew G. Howard, Menglong Zhu, Andrey Zhmoginov, & Liang-Chieh Chen (2018). Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification, Detection and Segmentation. CoRR, abs/1801.04381.
+2. Tsung-Yi Lin, Piotr Dollár, Ross B. Girshick, Kaiming He, Bharath Hariharan, & Serge J. Belongie (2016). Feature Pyramid Networks for Object Detection. CoRR, abs/1612.03144.
+3. Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott E. Reed, Cheng-Yang Fu, & Alexander C. Berg (2015). SSD: Single Shot MultiBox Detector. CoRR, abs/1512.02325.
+4. Jonathan Long, Evan Shelhamer, & Trevor Darrell (2014). Fully Convolutional Networks for Semantic Segmentation. CoRR, abs/1411.4038.
+

--- a/assets/docs/iree/models/ssd_mobilenet_v2_fpn_100/uint8/default/lite/1.md
+++ b/assets/docs/iree/models/ssd_mobilenet_v2_fpn_100/uint8/default/lite/1.md
@@ -1,0 +1,26 @@
+# Lite iree/ssd_mobilenet_v2_fpn_100/uint8/default/1
+
+A deployment format of iree/ssd_mobilenet_v2_fpn_100/uint8
+
+<!-- parent-model: iree/ssd_mobilenet_v2_fpn_100/uint8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_mobilenet_v2_fpn_100/uint8/default/1.tflite -->
+
+## Overview
+Mobilenet V2 with FPNLite head trained on COCO 2017, in `uint8`. Works with dynamic width and height. Achieves 20.6% mAP
+on COCO 2017 at 320x320 input.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `channels = 3`, and `height` and `width` can be any size. Values should be between `[0, 255]`.
+
+### Output
+Outputs are the activations from the box predictors at each feature map in `uint8` and are of the form:
+* Box predictor: `[batch, height, width, box_encoding * num_anchors]`, where `batch=1`, `height` and `width` vary depending on the size of the feature map, `box_encoding` are the box coordinates at [`y_center`, `x_center`, `box_height`, `box_width`] and `num_anchors` is the number of anchors as defined in the anchor configuration.
+* Class predictor: `[batch, height, width, num_classes * num_anchors]`, where `batch=1`, `height` and `width` vary depending on the size of the feature map, `num_classes` is 91 (including background class), `num_anchors` is the number of anchors as defined in the anchor configuration.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph.pb`: the frozen Tensorflow graph.
+* `ssd_mobilenet_v2_fpnlite_uint8.tflite`: the converted TFLite file with raw outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/fp32/1.md
+++ b/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/fp32/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/ssd_spaghettinet_edgetpu_large_320/fp32/1
+
+Spaghettinet EdgeTPU Large trained on COCO 2017, in `fp32`.
+
+<!-- task: image-object-detection -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: ssd-spaghettinet-edgetpu-large -->
+<!-- dataset: coco-2017 -->
+
+## Overview
+Spaghettinet EdgeTPU Large trained on COCO 2017, in `fp32`. Achieves 28.3% mAP
+on COCO 2017.
+
+### References
+https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md#pixel-6-edge-tpu-models

--- a/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/fp32/default/lite/1.md
+++ b/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/fp32/default/lite/1.md
@@ -1,0 +1,31 @@
+# Lite iree/ssd_spaghettinet_edgetpu_large_320/fp32/default/1
+
+A deployment format of iree/ssd_spaghettinet_edgetpu_large_320/fp32
+
+<!-- parent-model: iree/ssd_spaghettinet_edgetpu_large_320/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_spaghettinet_edgetpu_large_320/fp32/default/1.tflite -->
+
+## Overview
+Spaghettinet EdgeTPU Large trained on COCO 2017, in `fp32`. Achieves 28.3% mAP
+on COCO 2017.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `height = 320`, `width = 320`,
+    `channels = 3` i.e. `[1, 320, 320, 3]`. Values should be normalized to `[-1,
+    1]`.
+
+### Output
+*   `raw_outputs/box_encodings`: an `fp32` array of shape `[1, M, 4]` containing
+    decoded detection boxes without Non-Max suppression. `M` is the number of
+    raw detections.
+*   `raw_outputs/class_predictions`: a `fp32` array of shape `[1, M, 91]` and
+    contains class probabilities for raw detection boxes. `M` is the number of
+    raw detections.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph.pb`: the frozen Tensorflow graph with `anchors` included as a constant tensor.
+* `spaghettinet_edgetpu_l.tflite`: the converted TFLite file with raw outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/fp32/nms/lite/1.md
+++ b/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/fp32/nms/lite/1.md
@@ -1,0 +1,34 @@
+# Lite iree/ssd_spaghettinet_edgetpu_large_320/fp32/nms/1
+
+A deployment format of iree/ssd_spaghettinet_edgetpu_large_320/fp32
+
+<!-- parent-model: iree/ssd_spaghettinet_edgetpu_large_320/fp32 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_spaghettinet_edgetpu_large_320/fp32/nms/1.tflite -->
+
+## Overview
+Spaghettinet EdgeTPU Large trained on COCO 2017, in `fp32`. Achieves 28.3% mAP
+on COCO 2017.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `height = 320`, `width = 320`,
+    `channels = 3` i.e. `[1, 320, 320, 3]`. Values should be normalized to `[-1,
+    1]`.
+
+### Output
+*   `TFLite_Detection_PostProcess`: The detection boxes. An `fp32` array of
+    shape `[N, 4]` containing bounding box coordinates in the following order:
+    `[ymin, xmin, ymax, xmax]`.
+*   `TFLite_Detection_PostProcess:1`: The detection classes. An `fp32` array of
+    shape `[N]` containing detection class index from the label file.
+*   `TFLite_Detection_PostProcess:2`: The detection class scores. An `fp32`
+    array of shape `[N]` containing detection scores.
+*   `TFLite_Detection_PostProcess:3`: The number of detections `N`. A single
+    `fp32` value.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph_pp.pb`: the frozen Tensorflow graph with `TFLite_Detection_PostProcess` op attached.
+* `spaghettinet_edgetpu_l_nms.tflite`: the converted TFLite file with processed outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/uint8/1.md
+++ b/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/uint8/1.md
@@ -1,0 +1,16 @@
+# Placeholder iree/ssd_spaghettinet_edgetpu_large_320/uint8/1
+
+Spaghettinet EdgeTPU Large trained on COCO 2017, in `uint8`.
+
+<!-- task: image-object-detection -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- network-architecture: ssd-spaghettinet-edgetpu-large -->
+<!-- dataset: coco-2017 -->
+
+## Overview
+Spaghettinet EdgeTPU Large trained on COCO 2017, in `uint8`. Achieves 27.9% mAP
+on COCO 2017.
+
+### References
+https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md#pixel-6-edge-tpu-models

--- a/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/uint8/default/lite/1.md
+++ b/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/uint8/default/lite/1.md
@@ -1,0 +1,27 @@
+# Lite iree/ssd_spaghettinet_edgetpu_large_320/uint8/default/1
+
+A deployment format of iree/ssd_spaghettinet_edgetpu_large_320/uint8
+
+<!-- parent-model: iree/ssd_spaghettinet_edgetpu_large_320/uint8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_spaghettinet_edgetpu_large_320/uint8/default/1.tflite -->
+
+## Overview
+Model is in TFLite format for `uint8` inference. Achieves 27.9% mAP
+on COCO 2017.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `height = 320`, `width = 320`,
+    `channels = 3` i.e. `[1, 320, 320, 3]`. Values should be between `[0, 255]`.
+
+### Output
+Outputs are the activations from the box predictors at each feature map in `uint8` and are of the form:
+* Box predictor: `[batch, height, width, box_encoding * num_anchors]`, where `batch=1`, `height` and `width` vary depending on the size of the feature map, `box_encoding` are the box coordinates at [`y_center`, `x_center`, `box_height`, `box_width`] and `num_anchors` is the number of anchors as defined in the anchor configuration.
+* Class predictor: `[batch, height, width, num_classes * num_anchors]`, where `batch=1`, `height` and `width` vary depending on the size of the feature map, `num_classes` is 91 (including background class), `num_anchors` is the number of anchors as defined in the anchor configuration.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph_pp.pb`: the frozen Tensorflow graph with `anchors` included as a constant tensor.
+* `spaghettinet_edgetpu_l_uint8_nms.tflite`: the converted TFLite file with raw outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/uint8/nms/lite/1.md
+++ b/assets/docs/iree/models/ssd_spaghettinet_edgetpu_large_320/uint8/nms/lite/1.md
@@ -1,0 +1,34 @@
+# Lite iree/ssd_spaghettinet_edgetpu_large_320/uint8/nms/1
+
+A deployment format of iree/ssd_spaghettinet_edgetpu_large_320/uint8
+
+<!-- parent-model: iree/ssd_spaghettinet_edgetpu_large_320/uint8 -->
+<!-- asset-path: https://storage.googleapis.com/tfhub-lite-models/iree/lite-model/ssd_spaghettinet_edgetpu_large_320/uint8/nms/1.tflite -->
+
+## Overview
+Model is in TFLite format for `uint8` inference. Achieves 27.9% mAP
+on COCO 2017.
+
+### Input
+*   `normalized_input_image_tensor`: an `uint8` array of shape `[batch, height,
+    width, channels]` where `batch = 1`, `height = 320`, `width = 320`,
+    `channels = 3` i.e. `[1, 320, 320, 3]`. Values should be normalized to `[-1,
+    1]`.
+
+### Output
+*   `TFLite_Detection_PostProcess`: The detection boxes. An `fp32` array of
+    shape `[N, 4]` containing bounding box coordinates in the following order:
+    `[ymin, xmin, ymax, xmax]`.
+*   `TFLite_Detection_PostProcess:1`: The detection classes. An `fp32` array of
+    shape `[N]` containing detection class index from the label file.
+*   `TFLite_Detection_PostProcess:2`: The detection class scores. An `fp32`
+    array of shape `[N]` containing detection scores.
+*   `TFLite_Detection_PostProcess:3`: The number of detections `N`. A single
+    `fp32` value.
+
+## Artifacts
+Artifacts included:
+* `tflite_graph_pp.pb`: the frozen Tensorflow graph with `TFLite_Detection_PostProcess` op attached.
+* `spaghettinet_edgetpu_l_uint8_nms.tflite`: the converted TFLite file with processed outputs.
+* `anchors.pb`: the anchor file in proto binary format.
+* `anchors.pbtxt`: the anchor file in proto text format.

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -87,6 +87,8 @@ values:
     display_name: MobileBert uncased_L-24_H-128_B-512_A-4_F-4_OPT
   - id: mobilebert
     display_name: MobileBert
+  - id: mobilebert-edgetpu-s
+    display_name: MobileBert EdgeTPU Small
   - id: mobilenet
     display_name: MobileNet
   - id: mobilenet-v1
@@ -165,6 +167,10 @@ values:
     display_name: SSD Mobilenet V1
   - id: ssd-mobilenet-v2
     display_name: SSD Mobilenet V2
+  - id: ssd-mobilenet-v2-fpn
+    display_name: SSD Mobilenet V2 FPN
+  - id: ssd-spaghettinet-edgetpu-large
+    display_name: SSD Spaghettinet EdgeTPU Large
   - id: swivel
     display_name: Swivel
   - id: tacotron2


### PR DESCRIPTION
Models:
* MobileBert with 3x [1, 384] inputs and 2x [1, 384] outputs, in fp32 and int8.
* MobileBert EdgeTPU Small with 3x [1, 384] inputs and 2x [1, 384] outputs, in fp32 and int8.
* Mobilenet V1 100% 1x224x224x3 input, in fp32 and uint8.
* Mobilenet V2 100% 1x224x224x3 input, in fp32 and uint8.
* Mobilenet V3-Large 100% 1x224x224x3 input, in fp32 and uint8.
* SSD Mobilenet V1 100% 1x320x320x3 input, in fp32 and uint8.
* SSD Mobilenet V2 100% with dynamic width and height input, in fp32 and int8.
* SSD Mobilenet V2 FPN 100% with dynamic width and height input, in fp32 and uint8.
* SSD Spaghettinet EdgeTPU Large 1x320x320x3 input, in fp32 and uint8.

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
