### PR TITLE
add: swin transformers

### DIFF
--- a/assets/docs/sayakpaul/collections/swin/1.md
+++ b/assets/docs/sayakpaul/collections/swin/1.md
@@ -1,6 +1,6 @@
-# Collection sayakpaul/cait/1
+# Collection sayakpaul/swin/1
 
-Collection of CaiT models.
+Collection of Swin Transformers.
 
 <!-- dataset: imagenet-ilsvrc-2012-cls -->
 <!-- task: image-classification -->
@@ -79,7 +79,7 @@ for the `s3` model were gathered from [here](https://github.com/microsoft/Cream/
 
 ## Notes
 
-All the models output attention weights from each of the transformer blocks. The [classification Colab Notebook](https://colab.research.google.com/github/sayakpaul/cait-tf/blob/main/notebooks/classification.ipynb) shows how to fetch the attention weights for a given prediction image. 
+All the models output attention weights from each of the transformer blocks. The [classification Colab Notebook](https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb) shows how to fetch the attention weights for a given prediction image. 
 
 
 ## References

--- a/assets/docs/sayakpaul/collections/swin/1.md
+++ b/assets/docs/sayakpaul/collections/swin/1.md
@@ -1,0 +1,101 @@
+# Collection sayakpaul/cait/1
+
+Collection of CaiT models.
+
+<!-- dataset: imagenet-ilsvrc-2012-cls -->
+<!-- task: image-classification -->
+
+## Overview
+
+This collection contains different Swin Transformer [1, 2] models. For more details on the training protocols,
+please follow [3, 4]. The original model weights are provided from [3, 4]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting steps are available in [5].
+Some models in this collection were first pre-trained on ImageNet-22k and then fine-tuned on ImageNet-1k.
+Rest were directly pre-trained on ImageNet-1k. The former usually leads to better performance.
+
+Note that ImageNet-22k and ImageNet-21k refer to the same dataset.
+
+## About the models
+
+Models included in this collection have two variants: (1) off-the-shelf inference for image
+classification, (2) fine-tuning on downstream tasks. These models are accompanied by
+Colab Notebooks for demonstration purposes. 
+
+The table below provides a performance summary (ImageNet-1k validation set):
+
+| model_name                     |   top1_acc(%) |   top5_acc(%) |   orig_top1_acc(%) |
+|:------------------------------:|:-------------:|:-------------:|:------------------:|
+| swin_base_patch4_window7_224   |        85.134 |        97.48  |               85.2 |
+| swin_large_patch4_window7_224  |        86.252 |        97.878 |               86.3 |
+| swin_s3_base_224               |        83.958 |        96.532 |               84   |
+| swin_s3_small_224              |        83.648 |        96.358 |               83.7 |
+| swin_s3_tiny_224               |        82.034 |        95.864 |               82.1 |
+| swin_small_patch4_window7_224  |        83.178 |        96.24  |               83.2 |
+| swin_tiny_patch4_window7_224   |        81.184 |        95.512 |               81.2 |
+| swin_base_patch4_window12_384  |        86.428 |        98.042 |               86.4 |
+| swin_large_patch4_window12_384 |        87.272 |        98.242 |               87.3 |
+
+
+The `base` and `large` models were first pre-trained on the ImageNet-22k dataset and then fine-tuned
+on the ImageNet-1k dataset.
+
+[This directory](https://github.com/sayakpaul/swin-transformers-tf/tree/main/in1k-eval) provides details
+on how these numbers were generated. Original scores for all the models except for the `s3` ones were
+gathered from [here](https://github.com/microsoft/Swin-Transformer/blob/main/get_started.md). Scores
+for the `s3` model were gathered from [here](https://github.com/microsoft/Cream/tree/main/AutoFormerV2#model-zoo).
+
+### Image classifiers
+
+* [swin_base_patch4_window12_384](https://tfhub.dev/sayakpaul/swin_base_patch4_window12_384)
+* [swin_base_patch4_window7_224](https://tfhub.dev/sayakpaul/swin_base_patch4_window7_224)
+* [swin_large_patch4_window12_384](https://tfhub.dev/sayakpaul/swin_large_patch4_window12_384)
+* [swin_large_patch4_window7_224](https://tfhub.dev/sayakpaul/swin_large_patch4_window7_224)
+* [swin_small_patch4_window7_224](https://tfhub.dev/sayakpaul/swin_small_patch4_window7_224)
+* [swin_tiny_patch4_window7_224](https://tfhub.dev/sayakpaul/swin_tiny_patch4_window7_224)
+* [swin_base_patch4_window12_384_in22k](https://tfhub.dev/sayakpaul/swin_base_patch4_window12_384_in22k)
+* [swin_base_patch4_window7_224_in22k](https://tfhub.dev/sayakpaul/swin_base_patch4_window7_224_in22k)
+* [swin_large_patch4_window12_384_in22k](https://tfhub.dev/sayakpaul/swin_large_patch4_window12_384_in22k)
+* [swin_large_patch4_window7_224_in22k](https://tfhub.dev/sayakpaul/swin_large_patch4_window7_224_in22k)
+* [swin_s3_tiny_224](https://tfhub.dev/sayakpaul/swin_s3_tiny_224)
+* [swin_s3_small_224](https://tfhub.dev/sayakpaul/swin_s3_small_224)
+* [swin_s3_base_224](https://tfhub.dev/sayakpaul/swin_s3_base_224)
+
+
+### Feature extractors
+
+* [swin_base_patch4_window12_384_fe](https://tfhub.dev/sayakpaul/swin_base_patch4_window12_384_fe)
+* [swin_base_patch4_window7_224_fe](https://tfhub.dev/sayakpaul/swin_base_patch4_window7_224_fe)
+* [swin_large_patch4_window12_384_fe](https://tfhub.dev/sayakpaul/swin_large_patch4_window12_384_fe)
+* [swin_large_patch4_window7_224_fe](https://tfhub.dev/sayakpaul/swin_large_patch4_window7_224_fe)
+* [swin_small_patch4_window7_224_fe](https://tfhub.dev/sayakpaul/swin_small_patch4_window7_224_fe)
+* [swin_tiny_patch4_window7_224_fe](https://tfhub.dev/sayakpaul/swin_tiny_patch4_window7_224_fe)
+* [swin_base_patch4_window12_384_in22k_fe](https://tfhub.dev/sayakpaul/swin_base_patch4_window12_384_in22k_fe)
+* [swin_base_patch4_window7_224_in22k_fe](https://tfhub.dev/sayakpaul/swin_base_patch4_window7_224_in22k_fe)
+* [swin_large_patch4_window12_384_in22k_fe](https://tfhub.dev/sayakpaul/swin_large_patch4_window12_384_in22k_fe)
+* [swin_large_patch4_window7_224_in22k_fe](https://tfhub.dev/sayakpaul/swin_large_patch4_window7_224_in22k_fe)
+* [swin_s3_tiny_224_fe](https://tfhub.dev/sayakpaul/swin_s3_tiny_224_fe)
+* [swin_s3_small_224_fe](https://tfhub.dev/sayakpaul/swin_s3_small_224_fe)
+* [swin_s3_base_224_fe](https://tfhub.dev/sayakpaul/swin_s3_base_224_fe)'
+
+## Notes
+
+All the models output attention weights from each of the transformer blocks. The [classification Colab Notebook](https://colab.research.google.com/github/sayakpaul/cait-tf/blob/main/notebooks/classification.ipynb) shows how to fetch the attention weights for a given prediction image. 
+
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[3] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[4] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[5] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+
+## Acknowledgements
+
+* [Willi Gierke](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)

--- a/assets/docs/sayakpaul/swin_base_patch4_window12_384/1.md
+++ b/assets/docs/sayakpaul/swin_base_patch4_window12_384/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_base_patch4_window12_384/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_base_patch4_window12_384.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_base_patch4_window12_384_fe/1.md
+++ b/assets/docs/sayakpaul/swin_base_patch4_window12_384_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_base_patch4_window12_384_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_base_patch4_window12_384_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_base_patch4_window12_384_in22k/1.md
+++ b/assets/docs/sayakpaul/swin_base_patch4_window12_384_in22k/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_base_patch4_window12_384_in22k/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_base_patch4_window12_384_in22k.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_base_patch4_window12_384_in22k_fe/1.md
+++ b/assets/docs/sayakpaul/swin_base_patch4_window12_384_in22k_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_base_patch4_window12_384_in22k_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_base_patch4_window12_384_in22k_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_base_patch4_window7_224/1.md
+++ b/assets/docs/sayakpaul/swin_base_patch4_window7_224/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_base_patch4_window7_224/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_base_patch4_window7_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_base_patch4_window7_224_fe/1.md
+++ b/assets/docs/sayakpaul/swin_base_patch4_window7_224_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_base_patch4_window7_224_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_base_patch4_window7_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_base_patch4_window7_224_in22k/1.md
+++ b/assets/docs/sayakpaul/swin_base_patch4_window7_224_in22k/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_base_patch4_window7_224_in22k/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_base_patch4_window7_224_in22k.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_base_patch4_window7_224_in22k_fe/1.md
+++ b/assets/docs/sayakpaul/swin_base_patch4_window7_224_in22k_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_base_patch4_window7_224_in22k_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_base_patch4_window7_224_in22k_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_large_patch4_window12_384/1.md
+++ b/assets/docs/sayakpaul/swin_large_patch4_window12_384/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_large_patch4_window12_384/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_large_patch4_window12_384.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_large_patch4_window12_384_fe/1.md
+++ b/assets/docs/sayakpaul/swin_large_patch4_window12_384_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_large_patch4_window12_384_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_large_patch4_window12_384_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_large_patch4_window12_384_in22k/1.md
+++ b/assets/docs/sayakpaul/swin_large_patch4_window12_384_in22k/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_large_patch4_window12_384_in22k/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_large_patch4_window12_384_in22k.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_large_patch4_window12_384_in22k_fe/1.md
+++ b/assets/docs/sayakpaul/swin_large_patch4_window12_384_in22k_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_large_patch4_window12_384_in22k_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_large_patch4_window12_384_in22k_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_large_patch4_window7_224/1.md
+++ b/assets/docs/sayakpaul/swin_large_patch4_window7_224/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_large_patch4_window7_224/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_large_patch4_window7_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_large_patch4_window7_224_fe/1.md
+++ b/assets/docs/sayakpaul/swin_large_patch4_window7_224_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_large_patch4_window7_224_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_large_patch4_window7_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_large_patch4_window7_224_in22k/1.md
+++ b/assets/docs/sayakpaul/swin_large_patch4_window7_224_in22k/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_large_patch4_window7_224_in22k/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_large_patch4_window7_224_in22k.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_large_patch4_window7_224_in22k_fe/1.md
+++ b/assets/docs/sayakpaul/swin_large_patch4_window7_224_in22k_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_large_patch4_window7_224_in22k_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_large_patch4_window7_224_in22k_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_s3_base_224/1.md
+++ b/assets/docs/sayakpaul/swin_s3_base_224/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_s3_base_224/1
+
+Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_s3_base_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_s3_base_224_fe/1.md
+++ b/assets/docs/sayakpaul/swin_s3_base_224_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_s3_base_224_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_s3_base_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_s3_small_224/1.md
+++ b/assets/docs/sayakpaul/swin_s3_small_224/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_s3_small_224/1
+
+Swin Transformer model pre-trained on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_s3_small_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_s3_small_224_fe/1.md
+++ b/assets/docs/sayakpaul/swin_s3_small_224_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_s3_small_224_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_s3_small_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_s3_tiny_224/1.md
+++ b/assets/docs/sayakpaul/swin_s3_tiny_224/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_s3_tiny_224/1
+
+Swin Transformer model pre-trained on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_s3_tiny_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_s3_tiny_224_fe/1.md
+++ b/assets/docs/sayakpaul/swin_s3_tiny_224_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_s3_tiny_224_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_s3_tiny_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_small_patch4_window7_224/1.md
+++ b/assets/docs/sayakpaul/swin_small_patch4_window7_224/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_small_patch4_window7_224/1
+
+Swin Transformer model pre-trained on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_small_patch4_window7_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_small_patch4_window7_224_fe/1.md
+++ b/assets/docs/sayakpaul/swin_small_patch4_window7_224_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_small_patch4_window7_224_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_small_patch4_window7_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_tiny_patch4_window7_224/1.md
+++ b/assets/docs/sayakpaul/swin_tiny_patch4_window7_224/1.md
@@ -1,0 +1,52 @@
+# Module sayakpaul/swin_tiny_patch4_window7_224/1
+
+Swin Transformer model pre-trained on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_tiny_patch4_window7_224.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/classification.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for performing off-the-shelf classification. Please
+refer to the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* If the model was only pre-trained on the ImageNet-22k dataset, then please refer to [6]
+to know more about how to parse the predictions.
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+[6] [BiT ImageNet-22k model usage](https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+

--- a/assets/docs/sayakpaul/swin_tiny_patch4_window7_224_fe/1.md
+++ b/assets/docs/sayakpaul/swin_tiny_patch4_window7_224_fe/1.md
@@ -1,0 +1,48 @@
+# Module sayakpaul/swin_tiny_patch4_window7_224_fe/1
+
+Fine-tunable Swin Transformer model pre-trained on the ImageNet-1k dataset.
+
+<!-- asset-path: https://storage.googleapis.com/swin-tf/tars/swin_tiny_patch4_window7_224_fe.tar.gz  -->
+<!-- task: image-classification -->
+<!-- network-architecture: swin-transformer -->
+<!-- format: saved_model_2 -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- colab: https://colab.research.google.com/github/sayakpaul/swin-transformers-tf/blob/main/notebooks/finetune.ipynb -->
+
+## Overview
+
+This model is a Swin Transformer [1] pre-trained on the ImageNet-1k dataset. You can find the complete
+collection of Swin models on TF-Hub on [this page](https://tfhub.dev/sayakpaul/collections/swin/1).
+
+You can use this model for feature extraction and fine-tuning. Please refer to
+the Colab Notebook linked on this page for more details.
+
+## Notes
+
+* The original model weights are provided from [2]. There were ported to Keras models
+(`tf.keras.Model`) and then serialized as TensorFlow SavedModels. The porting
+steps are available in [3].
+* If the model handle contains `s3` then please refer to [4] for more details on the architecture. It's 
+original weights are available in [5].
+* The model can be unrolled into a standard Keras model and you can inspect its topology.
+To do so, first download the model from TF-Hub and then load it using `tf.keras.models.load_model`
+providing the path to the downloaded model folder.
+
+## References
+
+[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)
+
+[2] [Swin Transformers GitHub](https://github.com/microsoft/Swin-Transformer)
+
+[3] [Swin-TF GitHub](https://github.com/sayakpaul/swin-transformers-tf)
+
+[4] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)
+
+[5] [AutoFormerV2 GitHub](https://github.com/silent-chen/AutoFormerV2-model-zoo)
+
+## Acknowledgements
+
+* [Willi](https://ch.linkedin.com/in/willi-gierke)
+* [ML-GDE program](https://developers.google.com/programs/experts/)
+


### PR DESCRIPTION
Adds Swin Transformers [1, 2].

26 models: 13 for off-the-shelf image classification, 13 for transfer learning.

## References

[1] [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows Liu et al.](https://arxiv.org/abs/2103.14030)

[2] [Searching the Search Space of Vision Transformer by Chen et al.](https://arxiv.org/abs/2111.14725)