### PR TITLE
Add XCiT: Cross-Covariance Image Transformers

### DIFF
--- a/assets/docs/rishit-dagli/collections/xcit/1.md
+++ b/assets/docs/rishit-dagli/collections/xcit/1.md
@@ -70,3 +70,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/collections/xcit/1.md
+++ b/assets/docs/rishit-dagli/collections/xcit/1.md
@@ -1,0 +1,72 @@
+# Collection rishit-dagli/xcit/1
+Collection of XCiT: Cross-Covariance Image Transformers models.
+
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+
+## Overview
+
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+## About the models
+
+Models included in this collection have two variants: (1) off-the-shelf inference for image classification, (2) fine-tuning on downstream tasks. The table below provides a performance summary (ImageNet-1k validation set):
+
+| Model | #params | GFLOPS | top-1 acc. (%) |
+| --- | --- | --- | --- |
+| xcit_large_24_p8_224 | 189 M | 417.9 | 84.9 |
+| xcit_large_24_p8_384 | 189 M | 417.9 | 86.0 |
+| xcit_large_24_p16_224 | 189 M | 36.1 | 84.9 |
+| xcit_large_24_p16_384 | 189 M | 36.1 | 82.9 |
+| xcit_medium_24_p16_224 | 84 M | 16.2 | 82.7 |
+| xcit_medium_24_p16_384 | 84 M | 188.0 | 84.3 |
+| xcit_nano_12_p16_224 | 3 M | 6.4 | 77.8 |
+| xcit_small_12_p16_224 | 26 M | 4.8 | 83.3 |
+| xcit_small_24_p16_224 | 48 M | 9.1 | 83.9 |
+| xcit_tiny_12_p16_224 | 7 M | 1.2 | 78.6 |
+| xcit_tiny_24_p16_224 | 12 M | 2.3 | 80.4 |
+
+## Summary of Models
+
+## Image classifiers
+
+- https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224/1
+- https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384/1
+- https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1
+- https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1
+- https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1
+- https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1
+- https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1
+- https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1
+- https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1
+- https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1
+- https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1
+
+### Feature Extractors
+
+- https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1
+- https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1
+
+### Acknowledgements
+
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+### References
+
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_224/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_224_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_large_24_p16_224_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_224/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_large_24_p16_224/1
+# Module rishit-dagli/xcit_large_24_p16_224/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_224_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_224_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_224/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_large_24_p16_224/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_224_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_224/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_224_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_large_24_p16_224_fe/1
+# Module rishit-dagli/xcit_large_24_p16_224_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_224_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_224_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_224_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_224_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_224_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_large_24_p16_224_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_224_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_large_24_p16_224_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_224_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_384/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_384_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_large_24_p16_384_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_384/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_large_24_p16_384/1
+# Module rishit-dagli/xcit_large_24_p16_384/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_384_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_384_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (384, 384))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (384, 384))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_384/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_384/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_large_24_p16_384/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_384_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (384, 384))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_384_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_384_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_large_24_p16_384_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_384_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_large_24_p16_384_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_384_dist_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (384, 384))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_384_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_large_24_p16_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p16_384_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_large_24_p16_384_fe/1
+# Module rishit-dagli/xcit_large_24_p16_384_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_384_dist_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p16_384_dist_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (384, 384))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (384, 384))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_224/1.md
@@ -1,0 +1,110 @@
+# Module rishit-dagli/xcit_large_24_p8_224/1
+
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p8_224_dist.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+### Example use
+
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224/1")
+```
+
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+It can also be used within a `KerasLayer`:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224/1")
+```
+
+### A complete example
+
+Make sure to download the class names first:
+
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
+
+Here is a complete example to infer on an image:
+
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
+
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224/1")
+
+
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
+
+
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
+
+
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
+
+
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
+
+### Acknowledgements
+
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+### References
+
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_224/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_224/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p8_224_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_large_24_p8_224_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_224_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_224_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p8_224_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_large_24_p8_224_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_224_fe/1.md
@@ -1,0 +1,110 @@
+# Module rishit-dagli/xcit_large_24_p8_224_fe/1
+
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p8_224_dist_fe.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+### Example use
+
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224_fe/1")
+```
+
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+It can also be used within a `KerasLayer`:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224_fe/1")
+```
+
+### A complete example
+
+Make sure to download the class names first:
+
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
+
+Here is a complete example to infer on an image:
+
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
+
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224_fe/1")
+
+
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
+
+
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
+
+
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
+
+
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
+
+### Acknowledgements
+
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+### References
+
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_384/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p8_384_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_large_24_p8_384_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_384/1.md
@@ -1,0 +1,110 @@
+# Module rishit-dagli/xcit_large_24_p8_384/1
+
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p8_384_dist.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+### Example use
+
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384/1")
+```
+
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+It can also be used within a `KerasLayer`:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384/1")
+```
+
+### A complete example
+
+Make sure to download the class names first:
+
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
+
+Here is a complete example to infer on an image:
+
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
+
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384/1")
+
+
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (384, 384))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
+
+
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
+
+
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
+
+
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
+
+### Acknowledgements
+
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+### References
+
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_384/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_384_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p8_384_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_large_24_p8_384_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_384_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_large_24_p8_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_large_24_p8_384_fe/1.md
@@ -1,0 +1,110 @@
+# Module rishit-dagli/xcit_large_24_p8_384_fe/1
+
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_large_24_p8_384_dist_fe.tar.gz -->
+
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+### Overview
+
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+### Example use
+
+The saved model can be loaded directly:
+
+```py
+import tensorflow_hub as hub
+
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384_fe/1")
+```
+
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+It can also be used within a `KerasLayer`:
+
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384_fe/1")
+```
+
+### A complete example
+
+Make sure to download the class names first:
+
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
+
+Here is a complete example to infer on an image:
+
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
+
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384_fe/1")
+
+
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (384, 384))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
+
+
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
+
+
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
+
+
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
+
+### Acknowledgements
+
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+### References
+
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_224/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_224/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_medium_24_p16_224/1
+# Module rishit-dagli/xcit_medium_24_p16_224/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_224_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_224_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_224/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_224_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_medium_24_p16_224_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_224/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_medium_24_p16_224/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_224_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_224_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_224_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_medium_24_p16_224_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_224_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_224_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_medium_24_p16_224_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_224_dist_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_224_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_medium_24_p16_224_fe/1
+# Module rishit-dagli/xcit_medium_24_p16_224_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_224_dist_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_224_dist_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_384/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_384_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_medium_24_p16_384_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_384/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_medium_24_p16_384/1
+# Module rishit-dagli/xcit_medium_24_p16_384/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_384_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_384_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (384, 384))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (384, 384))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_384/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_384/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_384/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_medium_24_p16_384/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_384_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (384, 384))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_384_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_medium_24_p16_384_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_384_dist_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (384, 384))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_384_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_384_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_medium_24_p16_384_fe/1
+# Module rishit-dagli/xcit_medium_24_p16_384_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_384_dist_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_384_dist_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 384 x 384 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (384, 384))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (384, 384))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_medium_24_p16_384_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_medium_24_p16_384_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_medium_24_p16_384_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_medium_24_p16_384_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_nano_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_nano_12_p16_224/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_nano_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_nano_12_p16_224/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_nano_12_p16_224/1
+# Module rishit-dagli/xcit_nano_12_p16_224/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_nano_12_p16_224_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_nano_12_p16_224_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_nano_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_nano_12_p16_224/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_nano_12_p16_224_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_nano_12_p16_224_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_nano_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_nano_12_p16_224/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_nano_12_p16_224/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_nano_12_p16_224_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_nano_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_nano_12_p16_224_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_nano_12_p16_224_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_nano_12_p16_224_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_nano_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_nano_12_p16_224_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_nano_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_nano_12_p16_224_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_nano_12_p16_224_fe/1
+# Module rishit-dagli/xcit_nano_12_p16_224_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_nano_12_p16_224_dist_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_nano_12_p16_224_dist_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_nano_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_nano_12_p16_224_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_nano_12_p16_224_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_nano_12_p16_224_dist_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_small_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_12_p16_224/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_12_p16_224_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_small_12_p16_224_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_small_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_12_p16_224/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_small_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_12_p16_224/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_small_12_p16_224/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_12_p16_224_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_small_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_12_p16_224/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_small_12_p16_224/1
+# Module rishit-dagli/xcit_small_12_p16_224/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_12_p16_224_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_12_p16_224_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_small_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_12_p16_224_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_small_12_p16_224_fe/1
+# Module rishit-dagli/xcit_small_12_p16_224_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_12_p16_224_dist_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_12_p16_224_dist_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_small_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_12_p16_224_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_12_p16_224_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_small_12_p16_224_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_small_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_12_p16_224_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_small_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_12_p16_224_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_small_12_p16_224_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_12_p16_224_dist_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_small_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_24_p16_224/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_small_24_p16_224/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_24_p16_224_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_small_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_24_p16_224/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_24_p16_224_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_small_24_p16_224_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_small_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_24_p16_224/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_small_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_24_p16_224/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_small_24_p16_224/1
+# Module rishit-dagli/xcit_small_24_p16_224/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_24_p16_224_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_24_p16_224_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_small_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_24_p16_224_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_small_24_p16_224_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_24_p16_224_dist_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_small_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_24_p16_224_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_small_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_24_p16_224_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_small_24_p16_224_fe/1
+# Module rishit-dagli/xcit_small_24_p16_224_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_24_p16_224_dist_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_24_p16_224_dist_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_small_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_small_24_p16_224_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_small_24_p16_224_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_small_24_p16_224_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_tiny_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_12_p16_224/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_12_p16_224_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_tiny_12_p16_224_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_tiny_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_12_p16_224/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_tiny_12_p16_224/1
+# Module rishit-dagli/xcit_tiny_12_p16_224/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_12_p16_224_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_12_p16_224_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_tiny_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_12_p16_224/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_tiny_12_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_12_p16_224/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_tiny_12_p16_224/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_12_p16_224_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_tiny_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_12_p16_224_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_12_p16_224_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_tiny_12_p16_224_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_tiny_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_12_p16_224_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_tiny_12_p16_224_fe/1
+# Module rishit-dagli/xcit_tiny_12_p16_224_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_12_p16_224_dist_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_12_p16_224_dist_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_tiny_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_12_p16_224_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_tiny_12_p16_224_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_12_p16_224_dist_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_tiny_12_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_12_p16_224_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_tiny_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_24_p16_224/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_tiny_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_24_p16_224/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_tiny_24_p16_224/1
+
+    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: false -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_24_p16_224_dist.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/assets/docs/rishit-dagli/xcit_tiny_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_24_p16_224/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_tiny_24_p16_224/1
+# Module rishit-dagli/xcit_tiny_24_p16_224/1
 
-    XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
+XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset suitable for off-the-shelf classification.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: false -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_24_p16_224_dist.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: false -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_24_p16_224_dist.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for performing off-the-shelf classification.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_tiny_24_p16_224/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_24_p16_224/1.md
@@ -8,7 +8,7 @@ XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k
 <!-- fine-tunable: false -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_24_p16_224_dist.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_tiny_24_p16_224_dist.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_tiny_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_24_p16_224_fe/1.md
@@ -8,7 +8,7 @@ Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the
 <!-- fine-tunable: true -->
 <!-- license: mit -->
 <!-- format: saved_model_2 -->
-<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_24_p16_224_dist_fe.tar.gz -->
+<!-- asset-path: https://storage.googleapis.com/xcit/xcit_tiny_24_p16_224_dist_fe.tar.gz -->
 
 ### TF2 SavedModel
 This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.

--- a/assets/docs/rishit-dagli/xcit_tiny_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_24_p16_224_fe/1.md
@@ -1,111 +1,110 @@
- # Module rishit-dagli/xcit_tiny_24_p16_224_fe/1
+# Module rishit-dagli/xcit_tiny_24_p16_224_fe/1
 
-    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
 
-    <!-- task: image-classification -->
-    <!-- network-architecture: xcit -->
-    <!-- dataset: imagenet -->
-    <!-- fine-tunable: true -->
-    <!-- license: mit -->
-    <!-- format: saved_model_2 -->
-    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_24_p16_224_dist_fe.tar.gz -->
+<!-- task: image-classification -->
+<!-- network-architecture: xcit -->
+<!-- dataset: imagenet -->
+<!-- fine-tunable: true -->
+<!-- license: mit -->
+<!-- format: saved_model_2 -->
+<!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_24_p16_224_dist_fe.tar.gz -->
 
-    ### TF2 SavedModel
-    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+### TF2 SavedModel
+This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
 
-    ### Overview
+### Overview
 
-    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
 
-    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
 
-    ### Example use
+### Example use
 
-    The saved model can be loaded directly:
+The saved model can be loaded directly:
 
-    ```py
-    import tensorflow_hub as hub
+```py
+import tensorflow_hub as hub
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
-    ```
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
+```
 
-    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
 
-    It can also be used within a `KerasLayer`:
+It can also be used within a `KerasLayer`:
 
-    ```py
-    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
-    ```
+```py
+hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
+```
 
-    ### A complete example
+### A complete example
 
-    Make sure to download the class names first:
+Make sure to download the class names first:
 
-    ```sh
-    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
-    ```
+```sh
+!wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+```
 
-    Here is a complete example to infer on an image:
+Here is a complete example to infer on an image:
 
-    ```py
-    import tensorflow_hub as hub
-    import tensorflow as tf
-    import numpy as np
-    import requests
-    from PIL import Image
-    from io import BytesIO
+```py
+import tensorflow_hub as hub
+import tensorflow as tf
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
 
-    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
-
-
-    def preprocess_image(image):
-        image = np.array(image)
-        image_resized = tf.image.resize(image, (224, 224))
-        image_resized = tf.cast(image_resized, tf.float32)
-        image_resized / 127.5 - 1
-        # ImageNet stats
-        image_resized = tf.keras.layers.Normalization(
-            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
-        )(image_resized)
-        return tf.expand_dims(image_resized, 0).numpy()
+model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
 
 
-    def load_image_from_url(url):
-        response = requests.get(url)
-        image = Image.open(BytesIO(response.content))
-        image = preprocess_image(image)
-        return image
+def preprocess_image(image):
+    image = np.array(image)
+    image_resized = tf.image.resize(image, (224, 224))
+    image_resized = tf.cast(image_resized, tf.float32)
+    image_resized / 127.5 - 1
+    # ImageNet stats
+    image_resized = tf.keras.layers.Normalization(
+        mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+    )(image_resized)
+    return tf.expand_dims(image_resized, 0).numpy()
 
 
-    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
-        lines = f.readlines()
-    imagenet_int_to_str = [line.rstrip() for line in lines]
+def load_image_from_url(url):
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = preprocess_image(image)
+    return image
 
 
-    def infer_on_image(img_url, model):
-        image = load_image_from_url(img_url)
-        predictions = model.signatures["serving_default"](tf.constant(image))
-        logits = predictions["output"][0]
-        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
-        print("Predicted label: " + predicted_label)
+with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+    lines = f.readlines()
+imagenet_int_to_str = [line.rstrip() for line in lines]
 
 
-    infer_on_image(
-        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
-    )
-    ```
+def infer_on_image(img_url, model):
+    image = load_image_from_url(img_url)
+    predictions = model.signatures["serving_default"](tf.constant(image))
+    logits = predictions["output"][0]
+    predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+    print("Predicted label: " + predicted_label)
 
-    ### Acknowledgements
 
-    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+infer_on_image(
+    img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+)
+```
 
-    ### References
+### Acknowledgements
 
-    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
 
-    [2] XCiT official code: https://github.com/facebookresearch/xcit
+### References
 
-    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+[1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
 
-    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
-    
+[2] XCiT official code: https://github.com/facebookresearch/xcit
+
+[3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+[4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models

--- a/assets/docs/rishit-dagli/xcit_tiny_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_24_p16_224_fe/1.md
@@ -108,3 +108,5 @@ Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites
 [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
 
 [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+
+[5] Draw inspiration from Sayak's works namely: https://github.com/sayakpaul/swin-transformers-tf and https://github.com/sayakpaul/cait-tf

--- a/assets/docs/rishit-dagli/xcit_tiny_24_p16_224_fe/1.md
+++ b/assets/docs/rishit-dagli/xcit_tiny_24_p16_224_fe/1.md
@@ -1,0 +1,111 @@
+ # Module rishit-dagli/xcit_tiny_24_p16_224_fe/1
+
+    Fine-tunable XCiT: Cross-Covariance Image Transformers model, pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset.
+
+    <!-- task: image-classification -->
+    <!-- network-architecture: xcit -->
+    <!-- dataset: imagenet -->
+    <!-- fine-tunable: true -->
+    <!-- license: mit -->
+    <!-- format: saved_model_2 -->
+    <!-- asset-path: https://storage.googleapis.com/hub-models.appspot.com/xcit/xcit_tiny_24_p16_224_dist_fe.tar.gz -->
+
+    ### TF2 SavedModel
+    This is a [SavedModel in TensorFlow 2 format](https://www.tensorflow.org/hub/tf2_saved_model). Using it requires TensorFlow 2 (or 1.15) and TensorFlow Hub 0.5.0 or newer.
+
+    ### Overview
+
+    This model is a XCiT: Cross-Covariance Image Transformer [1] pre-trained on the ImageNet-22k dataset and was then fine-tuned on the ImageNet-1k dataset. You can find the complete collection of XCiT models on TF-Hub on [this page](https://tfhub.dev/rishit-dagli/collections/xcit/1). You can use this model for feature extraction and fine-tuning.
+
+    The self-attention operation underlying transformers yields global interactions between all tokens ,i.e. words or image patches, and enables flexible modelling of image data beyond the local interactions of convolutions. The flexibility comes with a quadratic complexity in time and memory, hindering application to long sequences and high-resolution images this paper proposes a "transposed" version of self-attention that operates across feature channels rather than tokens. The resulting cross-covariance attention (XCA) has linear complexity in the number of tokens, and allows efficient processing of high-resolution images. [1]
+
+    ### Example use
+
+    The saved model can be loaded directly:
+
+    ```py
+    import tensorflow_hub as hub
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
+    ```
+
+    The input images are expected to have color values in the range `[-1, 1]`, following the [common image input](https://www.tensorflow.org/hub/common_signatures/images#input) conventions. The expected size of the input images is height x width = 224 x 224 pixels by default in the defult channels last format. This outputs an array of size `[-1, 1000]` corresponding to the 1000 ImageNet-1K classes.
+
+    It can also be used within a `KerasLayer`:
+
+    ```py
+    hub_layer = hub.KerasLayer("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
+    ```
+
+    ### A complete example
+
+    Make sure to download the class names first:
+
+    ```sh
+    !wget https://storage.googleapis.com/bit_models/ilsvrc2012_wordnet_lemmas.txt -O ilsvrc2012_wordnet_lemmas.txt
+    ```
+
+    Here is a complete example to infer on an image:
+
+    ```py
+    import tensorflow_hub as hub
+    import tensorflow as tf
+    import numpy as np
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
+    model = hub.load("https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1")
+
+
+    def preprocess_image(image):
+        image = np.array(image)
+        image_resized = tf.image.resize(image, (224, 224))
+        image_resized = tf.cast(image_resized, tf.float32)
+        image_resized / 127.5 - 1
+        # ImageNet stats
+        image_resized = tf.keras.layers.Normalization(
+            mean=(0.485, 0.456, 0.406), variance=(0.052441, 0.050176, 0.050625)
+        )(image_resized)
+        return tf.expand_dims(image_resized, 0).numpy()
+
+
+    def load_image_from_url(url):
+        response = requests.get(url)
+        image = Image.open(BytesIO(response.content))
+        image = preprocess_image(image)
+        return image
+
+
+    with open("ilsvrc2012_wordnet_lemmas.txt", "r") as f:
+        lines = f.readlines()
+    imagenet_int_to_str = [line.rstrip() for line in lines]
+
+
+    def infer_on_image(img_url, model):
+        image = load_image_from_url(img_url)
+        predictions = model.signatures["serving_default"](tf.constant(image))
+        logits = predictions["output"][0]
+        predicted_label = imagenet_int_to_str[int(np.argmax(logits))]
+        print("Predicted label: " + predicted_label)
+
+
+    infer_on_image(
+        img_url="https://storage.googleapis.com/rishit-dagli.appspot.com/sample-images/A5m4ZG1.jpg", model=model
+    )
+    ```
+
+    ### Acknowledgements
+
+    Supported with Cloud TPUs from [Google's TPU Research Cloud (TRC)](https://sites.research.google/trc)
+
+    ### References
+
+    [1] Ali, A., Touvron, H., Caron, M., Bojanowski, P., Douze, M., Joulin, A., Laptev, I., Neverova, N., Synnaeve, G., Verbeek, J., and Jegou, H. 2021. XCiT: Cross-Covariance Image Transformers. In Advances in Neural Information Processing Systems (pp. 20014–20027). Curran Associates, Inc..
+
+    [2] XCiT official code: https://github.com/facebookresearch/xcit
+
+    [3] BiT ImageNet-22k model usage: https://tfhub.dev/google/bit/m-r50x1/imagenet21k_classification/1#usage
+
+    [4] PyTorch Image Models: https://github.com/rwightman/pytorch-image-models
+    

--- a/tags/network_architecture.yaml
+++ b/tags/network_architecture.yaml
@@ -243,3 +243,5 @@ values:
     display_name: DeiT
   - id: cait
     display_name: CaiT
+  - id: xcit
+    display_name: XCiT


### PR DESCRIPTION
Adds XCiT proposed in the paper "[XCiT: Cross-Covariance Image Transformers](https://arxiv.org/abs/2106.09681)". This PR creates a collection and contributes 22 new models: 11 for off-the-shelf inference and 11 for fine-tuning.

---

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
