### PR TITLE
Fix XCiT collections links

### DIFF
--- a/assets/docs/rishit-dagli/collections/xcit/1.md
+++ b/assets/docs/rishit-dagli/collections/xcit/1.md
@@ -31,31 +31,31 @@ Models included in this collection have two variants: (1) off-the-shelf inferenc
 
 ## Image classifiers
 
-- https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224/1
-- https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384/1
-- https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1
-- https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1
-- https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1
-- https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1
-- https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1
-- https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1
-- https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1
-- https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1
-- https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1
+- [xcit_large_24_p8_224](https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224/1)
+- [xcit_large_24_p8_384](https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384/1)
+- [xcit_large_24_p16_224](https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224/1)
+- [xcit_large_24_p16_384](https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384/1)
+- [xcit_medium_24_p16_224](https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224/1)
+- [xcit_medium_24_p16_384](https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384/1)
+- [xcit_nano_12_p16_224](https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224/1)
+- [xcit_small_12_p16_224](https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224/1)
+- [xcit_small_24_p16_224](https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224/1)
+- [xcit_tiny_12_p16_224](https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224/1)
+- [xcit_tiny_24_p16_224](https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224/1)
 
 ### Feature Extractors
 
-- https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1
-- https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1
+- [xcit_large_24_p8_224_fe](https://tfhub.dev/rishit-dagli/xcit_large_24_p8_224_fe/1)
+- [xcit_large_24_p8_384_fe](https://tfhub.dev/rishit-dagli/xcit_large_24_p8_384_fe/1)
+- [xcit_large_24_p16_224_fe](https://tfhub.dev/rishit-dagli/xcit_large_24_p16_224_fe/1)
+- [xcit_large_24_p16_384_fe](https://tfhub.dev/rishit-dagli/xcit_large_24_p16_384_fe/1)
+- [xcit_medium_24_p16_224_fe](https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_224_fe/1)
+- [xcit_medium_24_p16_384_fe](https://tfhub.dev/rishit-dagli/xcit_medium_24_p16_384_fe/1)
+- [xcit_nano_12_p16_224_fe](https://tfhub.dev/rishit-dagli/xcit_nano_12_p16_224_fe/1)
+- [xcit_small_12_p16_224_fe](https://tfhub.dev/rishit-dagli/xcit_small_12_p16_224_fe/1)
+- [xcit_small_24_p16_224_fe](https://tfhub.dev/rishit-dagli/xcit_small_24_p16_224_fe/1)
+- [xcit_tiny_12_p16_224_fe](https://tfhub.dev/rishit-dagli/xcit_tiny_12_p16_224_fe/1)
+- [xcit_tiny_24_p16_224_fe](https://tfhub.dev/rishit-dagli/xcit_tiny_24_p16_224_fe/1)
 
 ### Acknowledgements
 


### PR DESCRIPTION
I noticed that the model links on the [xcit collection](https://tfhub.dev/rishit-dagli/collections/xcit/1) are not rendered as well as included models pane does not appear. This PR fixes that.

---

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
