### PR TITLE
Publishing Universaldot ScaNN Model

### DIFF
--- a/assets/docs/universaldot/models/berta/1.md
+++ b/assets/docs/universaldot/models/berta/1.md
@@ -1,0 +1,86 @@
+# Module universaldot/berta/1
+
+Bidirectional Encoder Representations from Transformers Authority  (BERTA).
+
+<!-- TODO:Modify the file bellow -->
+
+<!-- colab: https://colab.research.google.com/github/google-research/bert/blob/master/predicting_movie_reviews_with_bert_on_tf_hub.ipynb -->
+<!-- dataset: wikipedia-and-bookscorpus -->
+<!-- asset-path: legacy -->
+<!-- network-architecture: transformer -->
+<!-- language: en -->
+<!-- fine-tunable: true -->
+<!-- format: hub -->
+<!-- task: text-embedding -->
+
+
+## Overview
+
+This module contains a deep bidirectional transformer trained on Wikipedia and
+the BookCorpus. The details are described in the paper "BERT: Pre-training of
+Deep Bidirectional Transformers for Language Understanding" [1].
+
+This module assumes pre-processed inputs from the BERT repository
+(https://github.com/google-research/bert)
+
+This modules outputs a representations for every token in the input sequence and
+a pooled representation of the entire input.
+
+#### Trainable parameters
+
+All parameters in the module are trainable, and fine-tuning all parameters is
+the recommended practice.
+
+#### Example use
+
+Please see
+https://github.com/google-research/bert/blob/master/run_classifier_with_tfhub.py
+for how the input preprocessing should be done to retrieve the input ids, masks,
+and segment ids.
+
+```
+bert_module = hub.Module(
+    "https://tfhub.dev/google/bert_cased_L-12_H-768_A-12/1",
+    trainable=True, tags={"train"} if training else None)
+bert_inputs = dict(
+    input_ids=input_ids,
+    input_mask=input_mask,
+    segment_ids=segment_ids)
+bert_outputs = bert_module(bert_inputs, signature="tokens", as_dict=True)
+pooled_output = bert_outputs["pooled_output"]
+sequence_output = bert_outputs["sequence_output"]
+```
+
+The pooled_output is a `[batch_size, hidden_size]` Tensor. The sequence_output
+is a `[batch_size, sequence_length, hidden_size]` Tensor.
+
+### Inputs
+
+We currently only support the `tokens` signature, which assumes pre-processed
+inputs. `input_ids`, `input_mask`, and `segment_ids` are `int32` Tensors of
+shape `[batch_size, max_sequence_length]`
+
+### Outputs
+
+The output dictionary contains:
+
+*   `pooled_output`: pooled output of the entire sequence with shape
+    `[batch_size, hidden_size]`.
+*   `sequence_output`: representations of every token in the input sequence with
+    shape `[batch_size, max_sequence_length, hidden_size]`.
+
+## Changelog
+
+#### Version 1
+
+*   Initial release.
+
+** TF2 SavedModel variants of bert models can be found in the
+[bert collection](https://tfhub.dev/google/collections/bert/1). **
+
+#### References
+
+[1] Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova. [BERT:
+Pre-training of Deep Bidirectional Transformers for Language
+Understanding](https://arxiv.org/abs/1810.04805). arXiv preprint
+arXiv:1810.04805, 2018.

--- a/assets/docs/universaldot/universaldot.md
+++ b/assets/docs/universaldot/universaldot.md
@@ -1,0 +1,11 @@
+# Publisher UniversalDot
+UNIVERSALDOT FOUNDATION
+
+[![Icon URL]](https://github.com/UniversalDot/documents/blob/master/logo/only-text-bk.png)
+
+## About
+UniversalDot Foundation is focused on creating applications for the decentralized internet.
+
+**GitHub**: https://github.com/UniversalDot
+WEB: https://www.universaldot.foundation
+Contact: info@universaldot.foundation


### PR DESCRIPTION
Google ScaNN combined with Universal Encoder for vector similarity search tasks.

Any pull request you open is subject to the TensorFlow Hub Terms of Service at www.tfhub.dev/terms and Google's Privacy Policy at https://www.google.com/policies/privacy.

We check modified Markdown files for validity using [this](https://github.com/tensorflow/tfhub.dev/blob/master/.github/workflows/contributions-validator.yml) GitHub Workflow. You can execute the same checks locally by passing the file paths of modified Markdown files (relative to the `assets/docs` directory) to validator.py e.g. `python3 ./tools/validator.py google/google.md google/models/albert_base/1.md ...`.
