### PR TITLE
chore: archive terms of service

### DIFF
--- a/terms_archive/TERMS.md
+++ b/terms_archive/TERMS.md
@@ -1,0 +1,381 @@
+> On January 24, 2022, we updated our TensorFlow Hub Additional Terms of Service
+> ("**Additional Terms**") to help clarify and make it easier to understand what
+> to expect as you use the service. These changes won't affect the way you use
+> TensorFlow Hub. You can access the Archived Terms
+> [here](./TERMS_ARCHIVE_202201.md) and a summary of the changes
+> [here](./TERMS_UPDATES.md).
+
+Effective January 24, 2022 \| [Archived
+version](./TERMS_ARCHIVE_202201.md)
+
+# TensorFlow Hub Additional Terms of Service
+
+Thank you for using TensorFlow Hub! By accessing or using TensorFlow Hub, you
+agree to be bound by: (1) the [Google Terms of
+Service](https://www.google.com/intl/ALL/policies/terms/index.html) (the
+**"Universal Terms"**); (2) these TensorFlow Hub Additional Terms of Service
+(the **"TensorFlow Hub Additional Terms"**); (3) the [Google Privacy
+Policy](https://www.google.com/intl/ALL/policies/privacy/index.html) (the
+**"Privacy Policy"**); and (4) any other operating rules, policies, and
+procedures that we may publish from time to time on TensorFlow Hub
+(collectively, the **"Terms"**). Please read the Terms carefully, starting with
+the Universal Terms. TensorFlow Hub is a "service" as defined in the Universal
+Terms. The Terms establish what you can expect from us as you use TensorFlow
+Hub, and what we expect from you, and they form a binding agreement between you
+and Google related to your use of TensorFlow Hub. If you are accepting these
+Terms on behalf of an organization or company, see the section in the Universal
+Terms called "[Using Google services on behalf of an organization or
+business](https://policies.google.com/terms#as-organization)".
+
+## A. Definitions
+
+All defined terms in the [Universal Terms](https://policies.google.com/terms)
+also apply to these TensorFlow Hub Additional Terms, along with the following
+definitions:
+
+**"content"** means any content provided, uploaded, shared, featured, or
+displayed through TensorFlow Hub, including text, data, articles, images,
+videos, photographs, audio, models, metadata, graphics, software, code,
+services, applications, designs, features, and other materials that are
+available on or via TensorFlow Hub - whether that content belongs to you, Google
+or other people or organizations.
+
+**"high risk activities"** <a name="hra"></a> means activities where the use or
+failure of the TensorFlow Hub services or content could lead to death, personal
+injury, or environmental damage (including operation of nuclear facilities, air
+traffic control, life support systems, or weaponry).
+
+**"including"** means including but not limited to.
+
+**"TensorFlow Hub"** means (a) the TensorFlow Hub website located at
+[http://www.tfhub.dev](http://www.tfhub.dev/) and all related subdomains, and
+(b) all services and content provided via such website and subdomains that are
+not user-generated content.
+
+## B. Acceptable Use
+
+### Basic Rules of Conduct
+
+The section in the Universal Terms called "[respect
+others](https://policies.google.com/terms#respect)" outlines the basic rules of
+conduct that apply to your use of TensorFlow Hub. You are responsible for (a)
+ensuring that your use of TensorFlow Hub is in compliance with those basic rules
+of conduct, and (b) obtaining any necessary consents from third parties that may
+be required under the Terms or by applicable law.
+
+### Content Restrictions
+
+In addition to any restrictions on your content as set forth in the Universal
+Terms, you also agree that your content:
+
+-   is not unlawful and does not promote unlawful activities;
+-   does not contain sexually obscene content;
+-   is not libelous, defamatory, or fraudulent;
+-   is not discriminatory or abusive toward any individual or group;
+-   does not contain or install any active malware or exploits, or use
+    TensorFlow Hub for exploit delivery (such as part of a related command and
+    control system);
+-   does not infringe on any legal right of any party, including [intellectual
+    property
+    rights](https://policies.google.com/terms/definitions#toc-terms-intellectual-property-rights);
+-   is not intended for [high risk activities](#hra);
+-   is not subject to the International Traffic in Arms Regulations (ITAR)
+    maintained by the U.S. Department of State;
+-   is not Protected Health Information ("**PHI**"), as defined under the Health
+    Insurance Portability and Accountability Act of 1996 as it may be amended
+    from time to time, and any regulations issued under it ("**HIPAA**").
+
+### Conduct Restrictions
+
+a.  You agree to not use TensorFlow Hub (including any content) to:
+
+  -   harass, abuse, threaten, or incite violence towards any individual or
+        group;
+  -   generate, distribute, publish, or facilitate unsolicited mass email,
+        promotions, advertising, or other solicitations ("**spam**");
+  -   engage in any other unlawful, invasive, infringing, discriminatory,
+        defamatory or fraudulent purpose (including phishing, creating a pyramid
+        scheme, or mirroring a website);
+  -   violate the privacy of any third party (including obtaining, posting, or
+        using another person's personal information without consent or
+        surveilling any individual in a manner that violates applicable law or
+        internationally acceptable norms);
+  -   violate or encourage the violation of any legal rights of others
+        (including allowing or assisting others to infringe or misappropriate
+        the [intellectual property
+        rights](https://policies.google.com/terms/definitions#toc-terms-intellectual-property-rights)
+        of others in violation of the [Digital Millennium Copyright
+        Act](https://support.google.com/legal/answer/1120734)) or engage in or
+        encourage any other illegal activity;
+  -   intentionally distribute viruses, worms, Trojan horses, corrupted files,
+        hoaxes, or other items of a destructive or deceptive nature;
+  -   interfere with the use of TensorFlow Hub or the equipment used to
+        provide TensorFlow Hub;
+  -   disable, interfere with or circumvent any aspect of TensorFlow Hub;
+  -   use TensorFlow Hub or any interfaces provided by TensorFlow Hub to
+        access any other product or service in a manner that violates or
+        circumvents the terms of service of such other product or service;
+  -   engage in [high risk activities](#hra);
+  -   engage in any purpose or in any manner involving PHI, if you are or
+        become a Covered Entity or Business Associated, as those terms are
+        defined in HIPAA.
+  -   contravene any widely accepted principles of international law and human
+        rights; or
+   -   use TensorFlow Hub or any content to directly or indirectly create,
+        train, or improve a substantially similar service to TensorFlow Hub
+        (except to the extent such restrictions are expressly prohibited by
+        applicable law).
+
+b.  You agree not to reproduce, duplicate, copy, sell, or resell any portion of
+    TensorFlow Hub without our express written permission in advance.
+
+### Third Party Terms
+
+In some situations, third party terms may apply to your use of TensorFlow Hub.
+For example: (a) you may be accessing content with its own terms or license
+agreements; (b) you may download an application with its own terms of service
+that integrates with TensorFlow Hub; or (c) content owned by us or third parties
+(but featured in or linked from TensorFlow Hub) may provide different or
+additional terms of service. If those additional terms conflict with these
+TensorFlow Hub Additional Terms or provisions in the other Terms, the more
+specific terms apply to the relevant content.
+
+### Scraping
+
+Scraping refers to extracting data from TensorFlow Hub via any process,
+including an automated process such as a bot or webcrawler. You may only scrape
+TensorFlow Hub for public, non-personal information for non-commercial research
+and only if any publications resulting from such research are open access. You
+may not scrape TensorFlow Hub for any other purposes, including spamming
+purposes, or for the purposes of selling TensorFlow Hub users' personal
+information for other uses, such as use by recruiters, headhunters, and job
+boards.
+
+### Excessive Bandwidth Use
+
+If we determine in our sole discretion that the bandwidth usage of your Google
+Account in connection with your use of TensorFlow Hub is significantly excessive
+in relation to other users, we reserve the right to suspend your Google Account
+or throttle TensorFlow Hub services related to your Google Account until you can
+reduce your bandwidth consumption.
+
+## C. Content Rights and Obligations
+
+### Responsibility for Your Content
+
+You may create or upload content while using TensorFlow Hub in compliance with
+the Terms. Any content that you upload, submit, store, send, or receive through
+TensorFlow Hub (your content) is subject to the Universal Terms, including the
+license in the "[License](https://policies.google.com/terms#license)" section.
+In addition, you are solely responsible for the contents of, and for any harm
+resulting from, any of your content that you post, upload, link to or otherwise
+make available via TensorFlow Hub, regardless of the form of your content. We
+are not responsible for any public display or misuse of your content.
+
+### TensorFlow Hub May Remove Content
+
+We do not pre-screen user-generated content on TensorFlow Hub, but Google
+reserves the right (though not the obligation) to refuse or remove any
+user-generated content that, in our sole discretion, violates the Terms or any
+other applicable terms or policies.
+
+### License Grant to Us
+
+In addition to the "[License](https://policies.google.com/terms#license)"
+section of the Universal Terms, you grant to Google and our affiliates,
+subcontractors, and assignees the right to store, organize, and display your
+content, and make incidental copies as necessary to provide TensorFlow Hub to
+users, including the right to: (i) copy your content to our database and make
+backups; (ii) display your content to you and other users; (iii) organize your
+content into a search index or otherwise analyze it on our servers; and (iv)
+share it with other users.
+
+### License Grant to Other Users
+
+In addition to the "License" section of the Universal Terms, you understand and
+agree that:
+
+a.  Any content you post publicly (including issues, comments, and contributions
+    to other users' repositories) may be viewed by other users.
+
+b.  By allowing content you control to be viewed by other users, you agree to
+    allow other users to view and \"fork\" such content (this means that others
+    may make their own copies of your content).
+
+c.  If you set your content to be viewed publicly, unless you explicitly state
+    otherwise clearly in such content, you grant each user of TensorFlow Hub the
+    following "MIT license" to such content:
+
+    "Copyright © <year> <copyright holders>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the \"Software\"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.\
+    THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE."
+
+### Contributions Under a Contribution License
+
+Whenever you make a contribution to other user content that is subject to a
+clear contribution license, you license your contribution to such content under
+the same terms, and you agree that you have the right to license your
+contribution under those terms.
+
+### Moral Rights
+
+You waive any moral rights that would prevent us from reasonably exercising the
+rights granted to us in the Terms. To the extent these TensorFlow Additional
+Terms or the other Terms are not enforceable by applicable law, you grant us the
+rights we need to use your content without attribution and to make reasonable
+adaptations of your content as necessary to provide TensorFlow Hub.
+
+### Use of Your Content
+
+Our use of your content is governed by the Terms, including the following
+sections of the Universal Terms: (a) "[Permission to use your
+content](https://policies.google.com/terms#toc-permission)"; (b)
+"[License](https://policies.google.com/terms#license)"; and (c) "[Your
+content](https://policies.google.com/terms#your-content-in-services)". In
+addition to the Terms, you also consent to us sharing information related to
+your use of content on TensorFlow Hub with the provider of such content or
+related to support for usage of such content, in each case in accordance with
+the Terms and the Privacy Policy.
+
+### Support for Content
+
+We are not responsible or liable for any technical support to any user for any
+content including any security updates or patches provided by you or other users
+(even if such updates or patches may appear in our content).
+
+## D. Intellectual Property
+
+Terms related to intellectual property rights (including ownership rights, your
+use of our trademarks and logos, and notices related to copyright infringement)
+are set forth in the Universal Terms, including in the sections called: (a)
+"Content in Google Services" (which describes the intellectual property rights
+to the content you find in our services, whether that content belongs to you,
+Google, or others); (b) "[What we expect from
+you](https://policies.google.com/terms#toc-what-we-expect)" (which says we
+retain any intellectual property rights we have in the services, including
+TensorFlow Hub); (c) "[License](https://policies.google.com/terms#license)"
+(which states, among other things, that you retain any intellectual property
+rights that you have in your content), along with the License section of these
+TensorFlow Hub Additional Terms; (d) "[Google
+content](https://policies.google.com/terms#google-content)" (which states that
+if you want to use our branding or logos, including those for TensorFlow Hub,
+please see the Google Brand Permissions page); and (e) "[Your
+content](https://policies.google.com/terms#your-content-in-services)" (which
+describes what to do if you think someone is infringing your intellectual
+property rights, [how to send us a notice of
+infringement](https://support.google.com/legal/answer/3110420), and how to
+access our [Copyright Help
+Center](https://support.google.com/legal/topic/4558877)).
+
+## E. General Terms
+
+In addition to those included in the Universal Terms, the following apply to
+your use of TensorFlow Hub:
+
+### Publicity
+
+You are permitted to state publicly that you are a user of TensorFlow Hub,
+consistent with the [Google Brand
+Permissions](https://www.google.com/permissions) page. If you want to display
+TensorFlow Hub branding or logos in connection with your use of TensorFlow Hub
+or in any other manner, you must obtain written permission from us through the
+process specified on the [Google Brand
+Permissions](https://www.google.com/permissions) page. We may include your name,
+branding and logos in a list of our users either online or in promotional
+materials. We may also verbally reference you as a user of TensorFlow Hub and of
+any content used by you. Any use of a party's branding or logos will inure to
+the benefit of the party holding [intellectual property
+rights](https://policies.google.com/terms/definitions#toc-terms-intellectual-property-rights)
+in and to such branding or logos. A party may revoke the other party's right to
+use its branding and logos under these TensorFlow Hub Additional Terms by
+providing written notice to the other party and a reasonable period to stop the
+use.
+
+### Additional Warranty Disclaimer
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, WE AND OUR SUPPLIERS DO NOT
+MAKE ANY WARRANTY OF ANY KIND RELATED TO TENSORFLOW HUB OR ANY CONTENT, WHETHER
+EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR USE AND NONINFRINGEMENT. WE AND OUR
+SUPPLIERS ARE NOT RESPONSIBLE OR LIABLE FOR THE DELETION OF OR FAILURE TO STORE
+ANY CONTENT AND OTHER COMMUNICATIONS MAINTAINED OR TRANSMITTED THROUGH USE OF
+TENSORFLOW HUB. YOU ARE SOLELY RESPONSIBLE FOR SECURING AND BACKING UP ANY
+CONTENT YOU UPLOAD TO OR ACCESS VIA TENSORFLOW HUB. WE AND OUR SUPPLIERS AND
+LICENSEES DO NOT WARRANT THAT THE OPERATION OF TENSORFLOW HUB OR ANY CONTENT
+WILL BE ERROR-FREE, MALWARE- FREE, OR UNINTERRUPTED. TENSORFLOW HUB AND ALL
+CONTENT ARE NOT DESIGNED, MANUFACTURED, OR INTENDED FOR HIGH RISK ACTIVITIES.
+
+### Notices
+
+All legal notices to us must be emailed to Our Legal Department at
+<legal-notices@google.com>. You agree that we may use the email address that you
+provide us for any notice to you. Notice will be treated as given on receipt, as
+verified by written or automated receipt or by electronic log (as applicable).
+
+### Government Users
+
+If you are using TensorFlow Hub on behalf of a government entity, the following
+terms apply:
+
+a.  If you are a city, county or state government entity in the United States or
+    European Union, the section in the Universal Terms regarding governing law
+    and venue will not apply.
+
+b.  If you are a U.S. federal government entity, then the section in the
+    Universal Terms regarding governing law and venue is replaced with the
+    following, solely to the extent permitted by U.S. federal law:
+
+    "ALL CLAIMS ARISING OUT OF OR RELATING TO THE "TERMS" (AS DEFINED IN THESE
+    TENSORFLOW HUB ADDITIONAL TERMS) OR THE TENSORFLOW HUB SERVICE WILL BE
+    GOVERNED BY AND INTERPRETED AND ENFORCED IN ACCORDANCE WITH THE LAWS OF THE
+    UNITED STATES OF AMERICA, EXCLUDING ITS CONFLICT OF LAWS RULES. SOLELY TO
+    THE EXTENT PERMITTED BY FEDERAL LAW: (I) THE LAWS OF THE STATE OF CALIFORNIA
+    (EXCLUDING CALIFORNIA'S CONFLICT OF LAWS RULES) WILL APPLY IN THE ABSENCE OF
+    APPLICABLE FEDERAL LAW; AND (II) ANY DISPUTE ARISING OUT OF OR RELATING TO
+    THE "TERMS" (AS DEFINED IN THESE TENSORFLOW HUB ADDITIONAL TERMS) OR THE
+    TENSORFLOW HUB SERVICE WILL BE LITIGATED EXCLUSIVELY IN THE FEDERAL COURTS
+    OF SANTA CLARA COUNTY, CALIFORNIA, AND, THE PARTIES CONSENT TO PERSONAL
+    JURISDICTION IN, AND THE EXCLUSIVE VENUE OF, THE COURTS IN SANTA CLARA
+    COUNTY, CALIFORNIA."
+
+c.  If You are any entity or person not stated in (a) or (b) above, then the
+    section in the Universal Terms regarding governing law and venue applies.
+
+### U.S. Federal Agency Users
+
+TensorFlow Hub and our content were developed solely at private expense and are
+commercial computer software and related documentation within the meaning of the
+applicable Federal Acquisition Regulation and agency supplements.
+
+### Term and Termination
+
+The Terms will continue to apply to your use of TensorFlow Hub until terminated
+by either you or Google as set forth in the Universal Terms and this paragraph.
+If you want to terminate these TensorFlow Hub Additional Terms, you may do so by
+deleting your Google Account and ceasing to use and access TensorFlow Hub.
+
+### Survival
+
+The following provisions in the Terms will survive termination: conduct
+restrictions (including those set forth in Section B.3), content rights and
+obligations (including those set forth in Section C), any obligation you have to
+indemnify us, any limitations on our liability, any terms regarding ownership or
+intellectual property rights (including those in Section D), terms regarding
+disputes between us, these General Terms in Section E, and any other provisions
+that, by their nature, should survive termination of these TensorFlow Additional
+Terms.

--- a/terms_archive/TERMS_ARCHIVE_202201.md
+++ b/terms_archive/TERMS_ARCHIVE_202201.md
@@ -1,0 +1,451 @@
+# TensorFlow Hub Terms of Service
+
+Thank you for using TensorFlow Hub! Please read the TensorFlow Hub Terms of
+Service carefully before accessing or using TensorFlow Hub because these terms
+represent the agreement between You and Google related to Your use of TensorFlow
+Hub.
+
+## The TensorFlow Hub Terms of Service
+
+Version date: October 30th 2019
+
+## A. Definitions
+
+1.  \"Account\" means authorization to use TensorFlow Hub on behalf of a User
+    and any other Users that User may permit to use the Account and a User's
+    identity on TensorFlow Hub.
+2.  "Account Information" means information and data shared by You with Us
+    related to Your Account as well as other information related to Your usage
+    of TensorFlow Hub, Services, and Content.
+3.  \"Affiliate\" means any entity that directly or indirectly Controls, is
+    Controlled by, or is under common Control with a party.
+4.  "Agreement" means, collectively, all the terms, conditions, notices
+    contained or referenced in this document (the "TensorFlow Hub Terms of
+    Service" or the \"Terms\") and all other operating rules, policies, and
+    procedures that we may publish from time to time on TensorFlow Hub.
+5.  "TensorFlow Hub" means the Website and other Services provided via the
+    Website.
+6.  "Brand Features" means the trade names, trademarks, service marks, logos,
+    domain names, and other distinctive brand features of each party,
+    respectively, as secured by such party from time to time.
+7.  "Confidential Information\" means information that one party (or an
+    Affiliate) discloses to the other party under this Agreement, and which is
+    marked as confidential or would normally under the circumstances be
+    considered confidential information. It does not include information that is
+    independently developed by the recipient, is rightfully given to the
+    recipient by a third party without confidentiality obligations, or becomes
+    public through no fault of the recipient.
+8.  "Content" means any content provided, uploaded, shared, featured, or
+    displayed through TensorFlow Hub, including text, data, articles, images,
+    videos, photographs, graphics, software, services, applications, designs,
+    features, and other materials that are available on TensorFlow Hub.
+9.  "Control" means control of greater than fifty percent of the voting rights
+    or equity interests of a party.
+10. "Effective Date" is the date that You accept this Agreement to use
+    TensorFlow Hub, or, if You are accessing TensorFlow Hub in a manner that
+    does not require active acceptance of this Agreement, the date You first
+    access TensorFlow Hub.
+11. \"Google\", "Our", "We," and "Us" means Google LLC, as well as Our
+    directors, subsidiaries, contractors, licensors, officers, agents, and
+    employees.
+12. "High Risk Activities" means activities where the use or failure of the
+    Services could lead to death, personal injury, or environmental damage
+    (including operation of nuclear facilities, air traffic control, life
+    support systems, or weaponry).
+13. "Including" means including but not limited to.
+14. "Indemnified Liabilities" means any: (i) settlement amounts approved by the
+    indemnifying party; and (ii) damages and costs finally awarded against the
+    indemnified party and its Affiliates by a court of competent jurisdiction.
+15. "Intellectual Property Rights" means current and future worldwide rights
+    under patent, copyright, trade secret, trademark, or moral rights laws, and
+    other similar rights.
+16. \"Legal Process\" means a data disclosure request made under law,
+    governmental regulation, court order, subpoena, warrant, governmental
+    regulatory or agency request, or other valid legal authority, legal
+    procedure, or similar process.
+17. "Services" means Content directly provided by TensorFlow Hub that is not
+    User-Generated Content.
+18. "Trademark Guidelines" means Our guidelines for third party use of our Brand
+    Features, located at: <http://www.google.com/permissions/guidelines.html>.
+19. "Terms URL" means <http://www.tfhub.dev/terms> or subsequent URLs where the
+    terms of this Agreement may be found.
+20. "Third-Party Legal Proceeding" means any formal legal proceeding filed by an
+    unaffiliated third party before a court or government tribunal (including
+    any appellate proceeding).
+21. "User" means any person or company that uses any aspect of TensorFlow Hub
+    via an Account. Special terms may apply for business or government Accounts.
+22. "User-Generated Content" means Content created, shared, or uploaded by Our
+    Users.
+23. The "Website" refers to the TensorFlow Hub's website located at
+    <http://www.tfhub.dev> and any related subdomains.
+24. "You," and "Your" means the individual person, company, or organization that
+    has visited or is using TensorFlow Hub via Your Account; that accesses or
+    uses any part of Your Account; or that directs the use of Your Account.
+25. "Your Content" is Content on TensorFlow Hub created or provided by You.
+
+## B. Account Terms
+
+### Account Requirements.
+
+-   A human must create Your Account, and You must be at least 13 years of age
+    (or any older age required by applicable law) to use TensorFlow Hub.
+    Accounts registered by \"bots\" or other automated methods are not
+    permitted.
+-   You must provide a valid email address, and You may not have more than one
+    free Account.
+
+### Account Controls
+
+-   You alone are responsible for Your Account and anything that happens while
+    You are using Your Account (including all Content posted and activity that
+    occurs under Your Account even when Content is posted by others who have
+    access to an Account where You are the owner).
+-   You are responsible for keeping your Account secure.
+-   You are responsible for maintaining the security of Your Account and
+    password. We are not liable for any loss or damage from Your failure to
+    comply with this security obligation.
+-   You will promptly [notify Us](mailto:hi-tf-hub@google.com) at
+    <hi-tf-hub@google.com> if You become aware of any unauthorized use of, or
+    access to, TensorFlow Hub or Your Account.
+-   If You are accepting these Terms on behalf of an organization or company,
+    You represent and warrant that: (i) You have full legal authority to bind
+    that organization or company to this Agreement; (ii) You have read and
+    understand this Agreement; and (iii) You agree, on behalf of the
+    organization or company, to this Agreement.
+
+### Required Information
+
+You must provide a valid email address and any other information required by Us,
+such as Your real name, to set-up an Account. If You are accepting these Terms
+and setting up an Account on behalf of a legal entity, We may need additional
+information about that legal entity.
+
+### Additional Terms
+
+In some situations, third party terms may apply to Your use of TensorFlow Hub.
+For example, You may be accessing Content with its own terms or license
+agreements; You may download an application with its own terms of service that
+integrates with TensorFlow Hub; or Content owned by Us or third parties (but
+featured in or linked from TensorFlow Hub) may provide different or additional
+terms of service. If those additional terms conflict with this Agreement, the
+more specific terms apply to the relevant Content (and associated webpages).
+
+## C. Acceptable Use
+
+### Compliance with Laws and Regulations
+
+Your use of TensorFlow Hub must not violate any applicable laws, including
+copyright, trademark, or export control laws. You are responsible for ensuring
+that Your use of TensorFlow Hub is in compliance with applicable law including
+obtaining any related consent from any third parties required by applicable law.
+
+### Content Restrictions
+
+You agree that Your Content:
+
+-   is not unlawful and does not promote unlawful activities;
+-   does not contain sexually obscene content;
+-   is not libelous, defamatory, or fraudulent;
+-   is not discriminatory or abusive toward any individual or group;
+-   does not contain or install any active malware or exploits, or use Our
+    platform for exploit delivery (such as part of a related command and control
+    system);
+-   does not infringe on any legal right of any party, including Intellectual
+    Property Rights;
+-   is not intended for High Risk Activities;
+-   is not subject to the International Traffic in Arms Regulations (ITAR)
+    maintained by the U.S. Department of State;
+-   is not Protected Health Information (PHI), as defined under the Health
+    Insurance Portability and Accountability Act of 1996 as it may be amended
+    from time to time, and any regulations issued under it (HIPAA).
+
+### Conduct Restrictions
+
+You agree to not use TensorFlow Hub (including any Content) to:
+
+-   harass, abuse, threaten, or incite violence towards any individual or group;
+-   generate, distribute, publish, or facilitate unsolicited mass email,
+    promotions, advertising, or other solicitations ("spam");
+-   engage in any other unlawful, invasive, infringing, discriminatory,
+    defamatory or fraudulent purpose (including phishing, creating a pyramid
+    scheme, or mirroring a website);
+-   violate the privacy of any third party (including obtaining, posting, or
+    using another person\'s personal information without consent or surveilling
+    any individual in a manner that violates applicable law or internationally
+    acceptable norms);
+-   violate or encourage the violation of any legal rights of others (including
+    allowing or assisting others to infringe or misappropriate the Intellectual
+    Property Rights of others in violation of the Digital Millennium Copyright
+    Act) or engage in or encourage any other illegal activity;
+-   intentionally distribute viruses, worms, Trojan horses, corrupted files,
+    hoaxes, or other items of a destructive or deceptive nature;
+-   interfere with the use of the TensorFlow Hub or the equipment used to
+    provide TensorFlow Hub;
+-   disable, interfere with or circumvent any aspect of TensorFlow Hub;
+-   use TensorFlow Hub or any interfaces provided by TensorFlow Hub to access
+    any other product or service in a manner that violates or circumvents the
+    terms of service of such other product or service;
+-   engage in High Risk Activities;
+-   engage in any purpose or in any manner involving PHI, if you are or become a
+    Covered Entity or Business Associated, as defined in HIPAA.
+-   contravene any widely accepted principles of international law and human
+    rights; or
+-   use TensorFlow Hub or any Content to directly or indirectly create, train,
+    or improve a substantially similar service to TensorFlow Hub (except to the
+    extent such restrictions are expressly prohibited by applicable law).
+
+### TensorFlow Hub Usage Limits
+
+You agree not to reproduce, duplicate, copy, sell, or resell any portion of
+TensorFlow Hub without Our express written permission.
+
+### Scraping
+
+Scraping refers to extracting data from Our TensorFlow Hub via any process
+including an automated process, such as a bot or webcrawler. You may only scrape
+the TensorFlow Hub for public, non-personal information for non-commercial
+research and only if any publications resulting from such research are open
+access. You may not scrape TensorFlow Hub for any other purposes, including
+spamming purposes, or for the purposes of selling TensorFlow Hub Users\'
+personal information for other uses such as by recruiters, headhunters, and job
+boards.
+
+### Excessive Bandwidth Use
+
+If We determine in Our sole discretion that the bandwidth usage of your Account
+is significantly excessive in relation to other Users, We reserve the right to
+suspend Your Account or throttle Services related to Your Account until You can
+reduce Your bandwidth consumption.
+
+### TensorFlow Hub May Terminate Use or Content
+
+We have the right to suspend or terminate Your Account and access to all or any
+part of TensorFlow Hub at any time, with or without cause, with or without
+notice, effective immediately. We may make changes to TensorFlow Hub or Content
+at any time including terminating the availability or use of any Content or
+Services.
+
+## D. Content Rights and Obligations
+
+1.  Responsibility for Your Content
+2.  TensorFlow Hub May Remove Content
+3.  Ownership of Content, Right to Post, and License Grants
+4.  License Grant to Us
+5.  License Grant to Other Users
+6.  Contributions Under License
+7.  Moral Rights
+8.  Use of Account Information and Your Content
+9.  Support for Content
+
+## E. Intellectual Property
+
+1.  Our Rights to TensorFlow Hub
+2.  TensorFlow Hub Trademarks and Logos
+3.  Copyright Infringement and DMCA Policy
+4.  Your Feedback
+5.  Remedies
+6.  U.S. Federal Agency Users
+
+## F. General Terms
+
+### Modifications to the Agreement
+
+We may make changes to this Agreement from time to time. We will post any
+changes to this Agreement to the Terms URL, and all changes will be effective
+immediately after posting. We advise You to review the latest version of the
+Agreement at the Terms URL before using TensorFlow Hub to stay informed of the
+most current Agreement terms applicable to such use. The foregoing
+notwithstanding, unless otherwise noted by Us, material changes to the Agreement
+will become effective 14 days after they are posted to the Terms URL, except
+changes that apply to new TensorFlow Hub functionality and Content, are
+necessary for the appropriate operation of TensorFlow Hub, or are required by
+applicable law will be effective immediately after they are posted to the Terms
+URL. If You do not agree to any changes to the Agreement, please stop using
+TensorFlow Hub and related Content. Any use by You of TensorFlow Hub or Content
+after the effective date of any changes to the Agreement posted to the Terms URL
+will constitute Your acceptance of the Agreement as modified.
+
+### Confidential Information
+
+The recipient will not disclose the Confidential Information, except to
+Affiliates, employees, agents or professional advisors who need to know it and
+who have agreed in writing (or in the case of professional advisors are
+otherwise bound) to keep it confidential. The recipient will ensure that those
+people and entities use the received Confidential Information only to exercise
+rights and fulfill obligations under this Agreement, while using reasonable care
+to keep it confidential. Notwithstanding any provision to the contrary in this
+Agreement, the recipient may also disclose Confidential Information to the
+extent required by applicable Legal Process if the recipient uses commercially
+reasonable efforts to: (i) promptly notify the other party of such disclosure
+before disclosing; and (ii) comply with the other party's reasonable requests
+regarding its efforts to oppose the disclosure. Notwithstanding the foregoing,
+subsections (i) or (ii) above will not apply if the recipient determines that
+complying with (i) or (ii) could: (a) result in a violation of Legal Process;
+(b) obstruct a governmental investigation; or (c) lead to death or serious
+physical harm to an individual. As between the parties, You are responsible for
+responding to all third party requests concerning Your use of TensorFlow Hub.
+
+### Term and Termination
+
+This Agreement will remain in effect from the Effective Date until terminated by
+either You or Us. If the Agreement expires or is terminated, then You will cease
+all use of TensorFlow Hub, and, upon request, each party will use commercially
+reasonable efforts to return or destroy all Confidential Information of the
+other party.
+
+### Publicity
+
+You are permitted to state publicly that You are a User of TensorFlow Hub,
+consistent with the Trademark Guidelines. If You want to display TensorFlow Hub
+Brand Features in connection with Your use of TensorFlow Hub, Your must obtain
+written permission from Us through the process specified in the Trademark
+Guidelines. We may include Your name or Brand Features in a list of Our Users
+either online or in promotional materials. We may also verbally reference You as
+a User of TensorFlow Hub and of any Content used by You. Neither party needs
+approval if it is repeating a public statement that is substantially similar to
+a previously approved public statement. Any use of a party's Brand Features will
+inure to the benefit of the party holding Intellectual Property Rights to those
+Brand Features. A party may revoke the other party's right to use its Brand
+Features under this Section with written notice to the other party and a
+reasonable period to stop the use.
+
+### Disclaimer
+
+EXCEPT AS OTHERWISE STATED IN THIS AGREEMENT, TO THE MAXIMUM EXTENT PERMITTED BY
+APPLICABLE LAW, WE AND OUR SUPPLIERS DO NOT MAKE ANY WARRANTY OF ANY KIND
+RELATED TO TENSORFLOW HUB OR ANY CONTENT, WHETHER EXPRESS, IMPLIED, STATUTORY OR
+OTHERWISE, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR USE
+AND NONINFRINGEMENT. WE AND OUR SUPPLIERS ARE NOT RESPONSIBLE OR LIABLE FOR THE
+DELETION OF OR FAILURE TO STORE ANY CONTENT AND OTHER COMMUNICATIONS MAINTAINED
+OR TRANSMITTED THROUGH USE OF TENSORFLOW HUB. YOU ARE SOLELY RESPONSIBLE FOR
+SECURING AND BACKING UP ANY CONTENT YOU UPLOAD TO OR ACCESS VIA TENSORFLOW HUB.
+WE AND OUR SUPPLIERS AND LICENSEES DO NOT WARRANT THAT THE OPERATION OF
+TENSORFLOW HUB OR ANY CONTENT WILL BE ERROR-FREE, MALWARE- FREE, OR
+UNINTERRUPTED. TENSORFLOW HUB AND ALL CONTENT ARE NOT DESIGNED, MANUFACTURED, OR
+INTENDED FOR HIGH RISK ACTIVITIES.
+
+### Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW WE AND OUR SUPPLIERS WILL NOT
+BE LIABLE UNDER THIS AGREEMENT FOR LOST REVENUES OR INDIRECT, SPECIAL,
+INCIDENTAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, EVEN IF WE OR OUR
+SUPPLIERS KNEW OR SHOULD HAVE KNOWN THAT SUCH DAMAGES WERE POSSIBLE AND EVEN IF
+DIRECT DAMAGES DO NOT SATISFY A REMEDY. TO THE MAXIMUM EXTENT PERMITTED BY
+APPLICABLE LAW, WE AND OUR SUPPLIERS, MAY NOT BE HELD LIABLE UNDER THIS
+AGREEMENT FOR MORE THAN THE AMOUNT PAID BY YOU TO US FOR USE OF TENSORFLOW HUB
+DURING THE THREE (3) MONTHS BEFORE THE EVENT GIVING RISE TO LIABILITY.
+
+### Indemnity by You
+
+Unless prohibited by applicable law, You will defend and indemnify Us and our
+Affiliates against Indemnified Liabilities in any Third-Party Legal Proceeding
+to the extent arising from: (i) any of Your Content; or (ii) Your use (or use by
+other Users under your Account) of TensorFlow Hub or any Content subject to the
+following conditions: (i) We have the right to approve controlling counsel, such
+approval not to be unreasonably withheld and which approval may be withheld or
+withdrawn if there is a conflict of interest); (ii) We may appoint Our own
+non-controlling counsel at Our own expense; and (iii) any settlement requiring
+Us to admit liability, pay money, or take (or refrain from taking) any action
+will require Our prior written consent.
+
+### Notices
+
+All legal notices to Us must be emailed to Our Legal Department at
+[legal-notices@google.com](https://pantheon.corp.google.com/legal-notices@google.com).
+You agree that We may use the email address that You provide Us for Your Account
+for any notice to You. Notice will be treated as given on receipt, as verified
+by written or automated receipt or by electronic log (as applicable).
+
+### Assignment
+
+You may not assign any part of this Agreement without Our written consent,
+except to an Affiliate where: (a) the assignee has agreed in writing to be bound
+by the terms of this Agreement; (b) the assigning party remains liable for
+obligations under the Agreement if the assignee defaults on them; and (c) the
+assigning party has notified the other party of the assignment. Any other
+attempt to assign is void.
+
+### Change of Control
+
+If You experience a change of Control (for example, through a stock purchase or
+sale, merger, or other form of corporate transaction): (a) You will give written
+notice to Us within 30 days after the change of Control; and (b) We may
+immediately terminate this Agreement upon receipt of that written notice.
+
+### Force Majeure
+
+We will not be liable for failure or delay in performance to the extent caused
+by circumstances beyond Our reasonable control.
+
+### No Agency
+
+This Agreement does not create any agency, partnership or joint venture between
+You and Us.
+
+### No Waiver
+
+We and You will be not be treated as having waived any rights by not exercising
+(or delaying the exercise of) any rights under this Agreement.
+
+### Severability
+
+If any term (or part of a term) of this Agreement is invalid, illegal, or
+unenforceable, the rest of the Agreement will remain in effect.
+
+### No Third-Party Beneficiaries
+
+This Agreement does not confer any benefits on any third party unless it
+expressly states that it does.
+
+### Equitable Relief
+
+Nothing in this Agreement will limit either party's ability to seek equitable
+relief.
+
+### Governing Law
+
+-   If You are a U.S. city, county or state government entity, then the
+    Agreement will be silent regarding governing law and venue.
+-   If You are a U.S. federal government entity then the following applies: ALL
+    CLAIMS ARISING OUT OF OR RELATING TO THIS AGREEMENT OR THE SERVICES WILL BE
+    GOVERNED BY THE LAWS OF THE UNITED STATES OF AMERICA, EXCLUDING ITS CONFLICT
+    OF LAWS RULES. SOLELY TO THE EXTENT PERMITTED BY FEDERAL LAW: (I) THE LAWS
+    OF THE STATE OF CALIFORNIA (EXCLUDING CALIFORNIA'S CONFLICT OF LAWS RULES)
+    WILL APPLY IN THE ABSENCE OF APPLICABLE FEDERAL LAW; AND (II) FOR ALL CLAIMS
+    ARISING OUT OF OR RELATING TO THIS AGREEMENT OR THE SERVICES, THE PARTIES
+    CONSENT TO PERSONAL JURISDICTION IN, AND THE EXCLUSIVE VENUE OF, THE COURTS
+    IN SANTA CLARA COUNTY, CALIFORNIA.
+-   If You are any entity or person not stated above in this Section then the
+    following applies: ALL CLAIMS ARISING OUT OF OR RELATING TO THIS AGREEMENT
+    OR THE SERVICES WILL BE GOVERNED BY CALIFORNIA LAW, EXCLUDING THAT STATE'S
+    CONFLICT OF LAWS RULES, AND WILL BE LITIGATED EXCLUSIVELY IN THE FEDERAL OR
+    STATE COURTS OF SANTA CLARA COUNTY, CALIFORNIA, USA; THE PARTIES CONSENT TO
+    PERSONAL JURISDICTION IN THOSE COURTS.
+
+### Survival
+
+The following Sections will survive expiration or termination of this Agreement:
+A, C.3, D, E, and F.
+
+### Entire Agreement
+
+This Agreement states all terms agreed between You and Us and supersedes all
+other agreements between You and Us relating to its subject matter. In entering
+into this Agreement, neither You or We have relied on, and neither You or We
+will have any right or remedy based on, any statement, representation or
+warranty (whether made negligently or innocently), except those expressly set
+out in this Agreement. The terms located at a URL referenced in the Agreement
+are incorporated by reference into the Agreement. After the Effective Date, We
+may provide an updated URL in place of any URL in this Agreement.
+
+### Conflicting Terms
+
+If there is a conflict among the documents that make up this Agreement, the
+documents will control in the following order: (i) the Agreement and (ii) any
+terms at any URL stated in this Agreement.
+
+### Counterparts
+
+If the parties execute this agreement offline, it may be executed in
+counterparts, including facsimile, PDF, and other electronic copies, which taken
+together will constitute one instrument.

--- a/terms_archive/TERMS_UPDATES.md
+++ b/terms_archive/TERMS_UPDATES.md
@@ -1,0 +1,40 @@
+# Updates to TensorFlow Hub Additional Terms of Service
+
+On January 24, 2022, we updated our TensorFlow Hub Additional Terms of Service
+("**Additional Terms**") to help clarify and make it easier to understand what
+to expect as you use the service. These changes won't affect the way you use
+TensorFlow Hub. You can access the Archived Terms
+[here](./TERMS_ARCHIVE_202201.md).
+
+At a glance, this update covers:
+
+**More clarity on what to expect:**
+
+We're providing more transparency about which terms apply to your use of
+TensorFlow Hub, such as Google's Terms of Service ("**uTOS**") and Privacy
+Policy. Those terms, along with these updated Additional Terms, provide clarity
+on how we develop, improve, and update our service, including more detail about
+the reasons we make changes and updates, and the advanced notice we provide to
+you.
+
+**General updates for improved readability:**
+
+While our Additional Terms remain a legal document, we've done our best to make
+them easier to understand. This includes:
+
+-   reorganizing some sections (such as *Third Party Terms* and *Term and
+    Termination*);
+-   rewording others (such as *Use of Your Content, Intellectual Property* and
+    *General Terms*); and
+-   removing provisions that are already covered in the uTOS (such as *Account
+    Terms*; certain provisions in the *Intellectual Property* section relating
+    to ownership, trademarks, copyrights, feedback, and remedies; and certain
+    *General Terms* relating to modifications to the agreement, confidential
+    information, limitation of liability, indemnities, and other general terms)
+    and providing helpful links to the uTOS provisions where applicable.
+
+Please make sure you read the updates to the Additional Terms. By continuing to
+use TensorFlow Hub after this date, you are agreeing to the updated Additional
+Terms.
+
+Thank you for being part of the TensorFlow community!


### PR DESCRIPTION
Archiving original terms of service now that tfhub.dev has been integrated with [Kaggle Models](https://www.kaggle.com/models?tfhub-redirect=true) (for googlers, b/299929715). 
